### PR TITLE
AIE-13: spec conformance in CI, plus release-triggered registry publishing (held)

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -1,0 +1,196 @@
+# Publish skills/ to agent-skill registries on release.
+#
+# This is the only path that contacts a registry, so the first listing and every
+# later refresh run the same reviewed code. It is merged inert and held behind four
+# independent gates; see docs/PUBLISHING.md for the operator's view.
+#
+#   1. Conformance  - the spec-conformance and skill-validator workflows must pass.
+#   2. Visibility   - the repository must be public, or a submitted URL would 404.
+#   3. Kill switch  - repository variable REGISTRY_PUBLISH_ENABLED must be "true".
+#   4. Approval     - the publish job runs in the "registries" environment, which
+#                     requires a reviewer. Neither registry documents a way to
+#                     delete a submission, so this gate is permanent, not just a
+#                     safeguard for the initial rollout.
+#
+# Gates 2 and 3 skip with a notice rather than failing: a release cut during the
+# hold period should not report a broken build.
+name: publish-registries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Render payloads without contacting any registry"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never let two releases submit concurrently; registries dedupe on their side but
+  # interleaved receipts would make it impossible to tell what was published.
+  group: publish-registries
+  cancel-in-progress: false
+
+jobs:
+  gate-spec:
+    uses: ./.github/workflows/spec-conformance.yml
+
+  gate-lint:
+    uses: ./.github/workflows/skill-validator.yml
+
+  preflight:
+    needs: [gate-spec, gate-lint]
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.decide.outputs.mode }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Decide publish mode
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # On a release there is no dry_run input, so the intent is a real publish.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          PUBLISH_ENABLED: ${{ vars.REGISTRY_PUBLISH_ENABLED }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "mode=dry-run" >> "$GITHUB_OUTPUT"
+            echo "Dry run requested: payloads will be rendered, no registry contacted."
+            exit 0
+          fi
+
+          visibility="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.visibility' | tr '[:upper:]' '[:lower:]')"
+          if [[ "${visibility}" != "public" ]]; then
+            echo "mode=blocked" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Publishing skipped::Repository is ${visibility}, not public. Registries require a public URL, so nothing was submitted."
+            exit 0
+          fi
+
+          if [[ "${PUBLISH_ENABLED}" != "true" ]]; then
+            echo "mode=held" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Publishing held::Repository variable REGISTRY_PUBLISH_ENABLED is not \"true\". Set it to go live; see docs/PUBLISHING.md."
+            exit 0
+          fi
+
+          echo "mode=publish" >> "$GITHUB_OUTPUT"
+          echo "All gates passed; publishing pends reviewer approval of the registries environment."
+
+  dry-run:
+    needs: preflight
+    if: needs.preflight.outputs.mode == 'dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # No registry is contacted here, including openagentskill's /validate endpoint,
+      # which reads SKILL.md over the public URL and so cannot work while the
+      # repository is internal. Calling it would report a failure that looks like a
+      # bug in this workflow rather than the expected state.
+      - name: Render payloads
+        run: |
+          set -euo pipefail
+          repo_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+
+          # Each script runs before anything is written to the summary so a failure
+          # surfaces as a failed step rather than being swallowed by a pipeline.
+          ./scripts/publish-openagentskill.sh --repo-url "${repo_url}" --dry-run | tee oas.txt
+          ./scripts/publish-upskill.sh --repo-url "${repo_url}" --dry-run | tee upskill.txt
+
+          {
+            echo "## Registry publish dry run"
+            echo
+            echo "No registry was contacted. Repository URL: \`${repo_url}\`"
+            echo
+            echo '### openagentskill'
+            echo '```json'
+            cat oas.txt
+            echo '```'
+            echo '### upskill'
+            echo '```'
+            cat upskill.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    needs: preflight
+    if: needs.preflight.outputs.mode == 'publish'
+    runs-on: ubuntu-latest
+    # Holds the job pending until a reviewer approves. Configure required reviewers
+    # on this environment, or the gate is decorative.
+    environment: registries
+    env:
+      UPSKILL_VERSION: 0.10.1
+      # Submitted tree URLs point at the default branch, not the release tag, so a
+      # listing keeps tracking updates instead of freezing at one release.
+      PUBLISH_REF: main
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Submit to openagentskill
+        run: |
+          ./scripts/publish-openagentskill.sh \
+            --repo-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --agent-id "aerospike-agent-skills-ci" \
+            --receipts receipts.jsonl
+
+      - name: Submit to upskill
+        run: |
+          # Pinned rather than floating: a CLI that no-ops when misconfigured is not
+          # one to auto-upgrade underneath us.
+          npm install -g "@autoloops/upskill@${UPSKILL_VERSION}"
+          ./scripts/publish-upskill.sh \
+            --repo-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --ref "${PUBLISH_REF}" \
+            --receipts receipts.jsonl
+
+      - name: Summarize submissions
+        if: always()
+        run: |
+          {
+            echo "## Registry submissions"
+            echo
+            if [[ -s receipts.jsonl ]]; then
+              echo "| Registry | Skill | Status |"
+              echo "|---|---|---|"
+              jq -r '"| " + .registry + " | " + .skill + " | " + .status + " |"' receipts.jsonl
+              echo
+              echo "Submission ids and status tokens are in the \`registry-receipts\` artifact."
+              echo "Transcribe them into \`docs/PUBLISHING.md\`; a token is the only way to poll a submission later."
+            else
+              echo "No receipts were written."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Receipts carry private status tokens, so they are archived rather than logged.
+      - name: Upload receipts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: registry-receipts
+          path: receipts.jsonl
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/skill-validator.yml
+++ b/.github/workflows/skill-validator.yml
@@ -17,6 +17,9 @@ on:
       - "skills/**"
       - ".github/workflows/skill-validator.yml"
       - "scripts/validate-skill.sh"
+  # Called by publish-registries.yml so a release cannot publish a tree with
+  # broken links or oversized references.
+  workflow_call:
 
 env:
   SKILL_VALIDATOR_VERSION: v1.5.5
@@ -60,7 +63,7 @@ jobs:
             echo "## skill-validator"
             set +e
             skill-validator check \
-              --allow-flat-layouts --allow-extra-frontmatter \
+              --allow-flat-layouts \
               -o markdown skills/
             sum=$?
             set -e

--- a/.github/workflows/spec-conformance.yml
+++ b/.github/workflows/spec-conformance.yml
@@ -1,0 +1,73 @@
+# Validates skills/ against the Agent Skills specification with the official
+# reference validator (agentskills/agentskills, skills-ref).
+#
+# This runs alongside skill-validator.yml on purpose. That workflow is a third-party
+# linter whose checks exceed the spec (links, token counts, layout); this one measures
+# conformance to the standard itself, which is what registries validate against.
+# Registry publishing (publish-registries.yml) gates on this job.
+#
+# Keep SKILLS_REF_REF in sync with scripts/validate-spec.sh.
+name: spec-conformance
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "scripts/validate-spec.sh"
+      - ".github/workflows/spec-conformance.yml"
+  push:
+    branches: [main, master, init]
+    paths:
+      - "skills/**"
+      - "scripts/validate-spec.sh"
+      - ".github/workflows/spec-conformance.yml"
+  # Called by publish-registries.yml so a release cannot publish a nonconformant tree.
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    env:
+      # skills-ref has no PyPI release, so it is installed from a pinned commit.
+      SKILLS_REF_REF: 69ef37e9424c0a7ea9dd2293b559e43ec8176379
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          # skills-ref requires >=3.11.
+          python-version: "3.12"
+
+      - name: Install skills-ref (official reference validator)
+        run: |
+          pip install \
+            "git+https://github.com/agentskills/agentskills.git@${SKILLS_REF_REF}#subdirectory=skills-ref"
+
+      - name: Validate skills against the spec
+        run: ./scripts/validate-spec.sh
+
+      - name: Append skill properties to job summary
+        if: always()
+        run: |
+          {
+            echo "## Agent Skills spec conformance"
+            echo
+            echo "Validator: \`skills-ref\` @ \`${SKILLS_REF_REF}\`"
+            echo
+            for skill_dir in skills/*/; do
+              [ -f "${skill_dir}SKILL.md" ] || continue
+              echo "### ${skill_dir%/}"
+              echo '```json'
+              skills-ref read-properties "${skill_dir%/}" || echo '{"error": "could not read properties"}'
+              echo '```'
+              echo
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@
 
 __pycache__/
 .idea/
+
+# Local eval harness working tree. The harness itself lives in a separate repo;
+# these hold API keys and raw model output that must never reach this repository.
+eval/
+results/
+.env
+.env.*
+!.env.example

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for helping improve this repository. It holds **Agent Skills** under [`sk
 
 ## Adding a new skill (especially Aerospike)
 
-1. Create `skills/<skill-name>/` with a required `SKILL.md` at the skill root. YAML **`name`** must match the parent folder name; **`description`** explains what and when; optional **`last_verified`** after you validate facts. For frontmatter shape, see an existing skill such as [`skills/aerospike-getting-started/SKILL.md`](skills/aerospike-getting-started/SKILL.md).
+1. Create `skills/<skill-name>/` with a required `SKILL.md` at the skill root. YAML **`name`** must match the parent folder name; **`description`** explains what and when; optional **`metadata.last_verified`** after you validate facts. For frontmatter shape, see an existing skill such as [`skills/aerospike-getting-started/SKILL.md`](skills/aerospike-getting-started/SKILL.md).
 2. Add any companion files inside that folder only (skill markdown must not link outside the skill directory—see validator note below).
 3. Run [`./scripts/validate-skill.sh`](scripts/validate-skill.sh) from the repo root and fix reported issues.
 4. Update [`skills/README.md`](skills/README.md) with a table row linking to the new `SKILL.md`.
@@ -45,9 +45,28 @@ Thanks for helping improve this repository. It holds **Agent Skills** under [`sk
 
 ## Skill frontmatter (`SKILL.md`)
 
-- **`name`:** Lowercase letters, numbers, hyphens; max 64 characters; must match the parent folder name.
-- **`description`:** Third person; include **what** the skill does and **when** to use it (trigger phrases). Stay under **1024** characters.
-- **`last_verified` (optional):** Bump this **ISO date** when you change commands, images, or product facts for **that skill**—after you have manually re-checked the documented flow.
+The [Agent Skills specification](https://agentskills.io/specification) defines a **closed** set of six frontmatter keys. Only these are allowed in a `SKILL.md`, and the official validator rejects anything else:
+
+`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`
+
+- **`name`:** Lowercase letters, numbers, hyphens; 1–64 characters; no leading, trailing, or consecutive hyphens; must match the parent folder name.
+- **`description`:** Third person; include **what** the skill does and **when** to use it (trigger phrases). 1–1024 characters.
+- **`license` (optional):** `Apache-2.0` for skills in this repository, matching [LICENSE](LICENSE). Registries factor license clarity into trust scoring.
+- **`metadata` (optional):** The spec's extension point—a map of string keys to **string** values. Anything not in the six keys above belongs here.
+- **`metadata.last_verified`:** Bump this **ISO date** when you change commands, images, or product facts for **that skill**—after you have manually re-checked the documented flow. **Quote it** (`"2026-04-21"`), because an unquoted YAML date parses to a date object and `metadata` values must be strings.
+
+```yaml
+---
+name: aerospike-getting-started
+description: >-
+  What the skill does, and when an agent should reach for it.
+license: Apache-2.0
+metadata:
+  last_verified: "2026-04-21"
+---
+```
+
+This closed key set applies to `SKILL.md` only. Companion files under `references/` are not skill manifests, so their frontmatter is free-form.
 
 ## Validate the skill package (skill-validator)
 
@@ -73,12 +92,30 @@ CI runs [agent-ecosystem/skill-validator](https://github.com/agent-ecosystem/ski
    - **Raw one-liner** (strict, same as local script default):
 
      ```bash
-     skill-validator check --strict --allow-flat-layouts --allow-extra-frontmatter skills/
+     skill-validator check --strict --allow-flat-layouts skills/
      ```
+
+   `--allow-flat-layouts` is intentional: `examples.md` and `reference.md` beside `SKILL.md` are spec-legal, and only this third-party tool objects to them. There is deliberately **no** `--allow-extra-frontmatter`, so an unexpected frontmatter key fails here instead of being waived.
 
    Optional: [Homebrew install](https://github.com/agent-ecosystem/skill-validator#install-cli) (`brew tap agent-ecosystem/tap && brew install skill-validator`) if you prefer not to use `go install`.
 
 **Note:** Skill markdown must not link **outside** the skill directory (e.g. no `../README.md`); describe repo-level files in prose instead.
+
+## Check spec conformance (skills-ref)
+
+Registries validate against the [Agent Skills specification](https://agentskills.io/specification), so this check is separate from the linter above: it answers only "does this frontmatter conform to the standard." CI runs it via [`.github/workflows/spec-conformance.yml`](.github/workflows/spec-conformance.yml).
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate   # requires Python 3.11+
+pip install "git+https://github.com/agentskills/agentskills.git@69ef37e9424c0a7ea9dd2293b559e43ec8176379#subdirectory=skills-ref"
+./scripts/validate-spec.sh
+```
+
+The commit is pinned because `skills-ref` has no PyPI release. Keep the pin in [`scripts/validate-spec.sh`](scripts/validate-spec.sh) and the workflow in sync.
+
+## Publishing to registries
+
+Submission is automated on release and gated behind conformance, public visibility, a kill-switch variable, and reviewer approval. Do not submit by hand—see [`docs/PUBLISHING.md`](docs/PUBLISHING.md).
 
 ## Before you open a pull request
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Copy **one or more** folders from `skills/<skill-name>/` into your tool’s skil
 | Tool | What to do |
 |------|----------------|
 | **Any agent (recommended)** | Add [`compiled-skills/SKILLS.md`](compiled-skills/SKILLS.md) to always-on context. [Install guide](compiled-skills/README.md). Raw URL: `https://raw.githubusercontent.com/aerospike/agent-skills/main/compiled-skills/SKILLS.md` |
+| **`skills` CLI (any supported agent)** | `npx skills add aerospike/agent-skills` installs the skill folders for you. |
 | **Cursor (skill folders)** | Copy `skills/aerospike-getting-started`, `skills/aerospike-development`, and/or `skills/aerospike-data-modeling` to `<project>/.cursor/skills/<same-folder-name>/` (or `~/.cursor/skills/` for all projects). Restart Cursor. Each skill is discovered via its YAML `description` in `SKILL.md`. |
 | **GitHub Copilot** | Uses [`.github/copilot-instructions.md`](.github/copilot-instructions.md) in supported clients; see also [AGENTS.md](AGENTS.md). |
 | **Claude Code / similar** | Open [CLAUDE.md](CLAUDE.md) and [AGENTS.md](AGENTS.md); for one file, use [`compiled-skills/SKILLS.md`](compiled-skills/SKILLS.md), or read skill bodies under `skills/*/`. |
@@ -95,8 +96,10 @@ Use this when your goal is a **running local database** and a **verified first c
 
 ## Maintenance and distribution
 
-- **`last_verified`:** Each skill’s `SKILL.md` may include `last_verified`. When you change Docker images, client commands, or major facts for **that** skill, re-check the documented flow and update the date.
+- **`metadata.last_verified`:** Each skill’s `SKILL.md` may carry `last_verified` under `metadata`. When you change Docker images, client commands, or major facts for **that** skill, re-check the documented flow and update the date.
 - **Linting skills:** Run `./scripts/validate-skill.sh` (see [CONTRIBUTING.md](CONTRIBUTING.md#validate-the-skill-package-skill-validator)); CI runs the same check via [`.github/workflows/skill-validator.yml`](.github/workflows/skill-validator.yml).
+- **Spec conformance:** Run `./scripts/validate-spec.sh` to check `SKILL.md` frontmatter against the [Agent Skills specification](https://agentskills.io/specification); CI runs it via [`.github/workflows/spec-conformance.yml`](.github/workflows/spec-conformance.yml).
+- **Publishing:** Registry submission is automated on release—see [`docs/PUBLISHING.md`](docs/PUBLISHING.md).
 - **Compiled skills:** `compiled-skills/` is generated from `skills/`. After editing any skill, run `python3 scripts/compile-agents.py --write`; CI fails the PR if the compiled output is stale.
 - **Contributing:** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add or edit skills and keep root docs in sync.
 - **Redistribution:** This repository is licensed under the [Apache License 2.0](LICENSE), matching [aerospike/data-modeling-guide](https://github.com/aerospike/data-modeling-guide).

--- a/compiled-skills/README.md
+++ b/compiled-skills/README.md
@@ -18,6 +18,12 @@ https://raw.githubusercontent.com/aerospike/agent-skills/main/compiled-skills/SK
 2. Add it to your agent's **always-on context** (project rules, system prompt, knowledge base, or repo instructions).
 3. See [`AGENTS.md`](../AGENTS.md) for a short overview.
 
+**Prefer the full skill folders?** With the [`skills` CLI](https://skills.sh):
+
+```bash
+npx skills add aerospike/agent-skills
+```
+
 ## By tool
 
 | Tool | What to do |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,134 @@
+# Publishing to agent-skill registries
+
+Registry submission is automated. [`.github/workflows/publish-registries.yml`](../.github/workflows/publish-registries.yml) is the **only** thing in this repository that contacts a registry, so the first listing and every later refresh run the same reviewed code. Nobody should submit by hand.
+
+This document is for whoever cuts a release, or turns publishing on for the first time.
+
+## How to publish
+
+Cut a GitHub release. That is the whole procedure — then approve the environment prompt when GitHub asks.
+
+To rehearse without submitting anything, run the workflow manually from the Actions tab with **Run workflow**. The `dry_run` input defaults to `true`, which renders the exact payloads into the job summary and contacts nothing.
+
+## The four gates
+
+Every gate must pass before a single request leaves the runner.
+
+```mermaid
+flowchart TD
+    Rel[release published] --> Conf[1: conformance workflows]
+    Conf --> Vis[2: repository is public]
+    Vis --> Flag[3: REGISTRY_PUBLISH_ENABLED is true]
+    Flag --> Env[4: registries environment approval]
+    Env --> Submit[submit to openagentskill + upskill]
+    Conf -->|fail| Fail[workflow fails, nothing submitted]
+    Vis -->|not public| Skip[skipped with a notice]
+    Flag -->|not true| Skip
+```
+
+| Gate | Mechanism | Why |
+|------|-----------|-----|
+| 1. Conformance | `needs:` on [`spec-conformance.yml`](../.github/workflows/spec-conformance.yml) and [`skill-validator.yml`](../.github/workflows/skill-validator.yml) | Never publish a tree that fails the standard. The pull request run does not prove the tag is clean. |
+| 2. Visibility | `gh api repos/... --jq .visibility` must be `public` | Every registry validates a public URL. Submitting a link that 404s wastes our one credible shot with that registry. |
+| 3. Kill switch | Repository variable `REGISTRY_PUBLISH_ENABLED` must be exactly `true` | The deliberate hold, and the rollback. Setting it back to `false` stops all publishing without reverting code. |
+| 4. Approval | The publish job runs in the `registries` environment | Neither registry documents a way to delete a submission, so a human confirms every one. **Permanent, not just for the initial rollout.** |
+
+Gates 2 and 3 **skip with a notice** instead of failing, so a release cut while publishing is held does not produce a red build. Gate 1 fails hard.
+
+## Turning publishing on for the first time
+
+Prerequisites: the repository is public, and open-source sign-off is recorded on [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
+
+1. Run the workflow manually with `dry_run: true` and confirm the rendered payloads look right. Do this after the repository is public — openagentskill's `/validate` endpoint reads `SKILL.md` over the public URL, so it is the first check that can only pass once we are public.
+2. Create the `registries` environment (**Settings → Environments**) and add the [code owners](../.github/CODEOWNERS) as **required reviewers**. Without reviewers configured, gate 4 does nothing.
+3. Set the repository variable (**Settings → Variables → Actions**): `REGISTRY_PUBLISH_ENABLED` = `true`.
+4. Cut a release, or run the workflow with `dry_run: false`.
+5. Approve the pending environment prompt.
+6. Verify each listing URL resolves and record it in the table below.
+
+## Registries
+
+### openagentskill.com — primary
+
+- **Listing:** https://www.openagentskill.com
+- **Mechanism:** public `POST /api/skills/submit`. No account, free, and zero-star repositories are explicitly accepted.
+- **Script:** [`scripts/publish-openagentskill.sh`](../scripts/publish-openagentskill.sh)
+
+The script resolves the repository through `POST /api/skills/validate` first, then submits one payload per skill:
+
+```json
+{
+  "repository": "https://github.com/aerospike/agent-skills",
+  "skillPath": "skills/aerospike-development/SKILL.md",
+  "submissionSource": "agent",
+  "submittedByAgent": "aerospike-agent-skills-ci"
+}
+```
+
+Two behaviors worth knowing:
+
+- **Re-submission is expected and safe.** A duplicate response is treated as success, which is what makes a release-triggered refresh idempotent.
+- **Listed and recommended are different states.** Only Reviewed, Verified, or Agent Proven skills enter default agent recommendations. Appearing in the directory does not mean agents will suggest us.
+
+Each submission returns `{id, token, statusUrl}`. **The token is the only way to poll that submission later.** Tokens are private, so the workflow keeps them out of logs and the job summary, uploading them as the `registry-receipts` artifact (90-day retention). Transcribe them into the table below before the artifact expires.
+
+### upskill (Autoloops) — secondary
+
+- **Listing:** https://upskill.autoloops.ai/
+- **Mechanism:** CLI publish with `@autoloops/upskill`, pinned in the workflow.
+- **Script:** [`scripts/publish-upskill.sh`](../scripts/publish-upskill.sh)
+
+The trap here is worth stating plainly: submissions are **disabled by default**, and `upskill submit` exits **successfully while doing nothing** when they are off. A naive workflow reports a green publish that never happened. The script therefore sets `submissions true` and then verifies the setting landed in `~/.config/upskill/config.json`, failing if it did not and warning loudly if the config file cannot be found.
+
+Skills land in the `community` trust tier. Promotion to `reviewed` or `verified` is on upskill's roadmap and has no documented criteria or SLA, so do not promise a timeline.
+
+Submitted URLs point at the **default branch**, not the release tag, so a listing keeps tracking updates rather than freezing at one release.
+
+### skills.sh — best-effort, nothing to automate
+
+- **Listing:** https://skills.sh (operated by Vercel)
+- **Mechanism:** **none.** There is no form, no API, and no index repository to open a pull request against.
+
+skills.sh indexes only what arrives through anonymous install telemetry from the `skills` CLI. Widely-circulated advice to open a pull request against `vercel-labs/skills` is wrong; the issue asking exactly that ([#880](https://github.com/vercel-labs/skills/issues/880)) is open and unanswered, and a pull request documenting that listing is telemetry-driven ([#1482](https://github.com/vercel-labs/skills/pull/1482)) is unmerged.
+
+What we can do, and have done:
+
+- Publish `npx skills add aerospike/agent-skills` in [`README.md`](../README.md) and [`compiled-skills/README.md`](../compiled-skills/README.md), because real installs are the only input to their index.
+- Ship [`skills.sh.json`](../skills.sh.json) so the repository page groups our three skills sensibly once it appears. This is display-only and does not affect whether we are listed.
+
+Note the known gap where install telemetry registers but the detail page still 404s ([#1610](https://github.com/vercel-labs/skills/issues/1610)). This is why skills.sh cannot be one of the committed listings for [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
+
+### Not a registry: agentskills.io
+
+`agentskills.io` hosts the **specification**, not a directory. Its [CONTRIBUTING.md](https://github.com/agentskills/agentskills/blob/main/CONTRIBUTING.md) says: "Skill submissions — We don't maintain a directory of community skills. This may change in the future." `/submit`, `/registry`, and `/skills` all 404. We conform to its spec (see below) but cannot list there.
+
+## Adding another registry
+
+1. Add a `scripts/publish-<registry>.sh` that supports `--dry-run` and appends JSON receipts, matching the two existing scripts.
+2. Add a step to the `publish` job in [`publish-registries.yml`](../.github/workflows/publish-registries.yml), and a rendering line to the `dry-run` job.
+3. Document the mechanism and any traps in this file.
+
+Keeping submission logic in scripts rather than inline YAML is deliberate: a maintainer can dry-run it locally without pushing a branch.
+
+## Spec conformance
+
+Registries validate against the [Agent Skills specification](https://agentskills.io/specification), so conformance is a publishing prerequisite, not a formality.
+
+```bash
+./scripts/validate-spec.sh   # official skills-ref validator, spec conformance only
+./scripts/validate-skill.sh  # third-party linter: links, token counts, layout
+```
+
+Both run in CI on every pull request that touches `skills/`. The spec allows only six frontmatter keys — `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` — and anything else, including our `last_verified`, belongs under `metadata`. See [CONTRIBUTING.md](../CONTRIBUTING.md#skill-frontmatter-skillmd).
+
+`skills-ref` has no PyPI release and describes itself as a demonstration library, so it is installed from a pinned commit recorded in both [`scripts/validate-spec.sh`](../scripts/validate-spec.sh) and [`spec-conformance.yml`](../.github/workflows/spec-conformance.yml). Keep the two in sync.
+
+## Live listings
+
+Fill in as submissions land, and record the same links on [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
+
+| Registry | Listing URL | Submission id | First submitted | Notes |
+|----------|-------------|---------------|-----------------|-------|
+| openagentskill | _pending_ | _pending_ | _pending_ | Tokens in the `registry-receipts` artifact |
+| upskill | _pending_ | n/a | _pending_ | `community` trust tier |
+| skills.sh | _pending_ | n/a | n/a | Telemetry-driven; no submission |

--- a/scripts/publish-openagentskill.sh
+++ b/scripts/publish-openagentskill.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Submit every skill under skills/ to openagentskill.com.
+#
+# Called by .github/workflows/publish-registries.yml, and runnable by hand for
+# debugging. Submission is idempotent: a duplicate response counts as success, so
+# re-running on a later release refreshes rather than errors.
+#
+# Docs: https://www.openagentskill.com/submit
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API="${OAS_API:-https://openagentskill.com/api}"
+REPO_URL=""
+AGENT_ID="aerospike-agent-skills-ci"
+RECEIPTS=""
+DRY_RUN=0
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: publish-openagentskill.sh --repo-url URL [options]
+
+  --repo-url URL     Public GitHub URL of this repository (required).
+  --agent-id ID      Value for submittedByAgent. Default: aerospike-agent-skills-ci
+  --receipts FILE    Append one JSON receipt per skill to FILE.
+  --dry-run          Render and check payloads; make no network calls.
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-url) REPO_URL="${2:?--repo-url needs a value}"; shift 2 ;;
+    --agent-id) AGENT_ID="${2:?--agent-id needs a value}"; shift 2 ;;
+    --receipts) RECEIPTS="${2:?--receipts needs a value}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+[[ -n "${REPO_URL}" ]] || { echo "--repo-url is required." >&2; usage; }
+for tool in curl jq; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "${tool} is required." >&2; exit 3; }
+done
+
+mapfile -t skill_dirs < <(find "${ROOT}/skills" -mindepth 1 -maxdepth 1 -type d | sort)
+[[ "${#skill_dirs[@]}" -gt 0 ]] || { echo "No skills found under skills/." >&2; exit 1; }
+
+# The /validate endpoint fetches SKILL.md over the public URL, so it cannot succeed
+# while the repository is private or internal. Skipped in dry-run for that reason:
+# calling it before the repo is public reports a failure that looks like our bug.
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  echo "Resolving skill paths via ${API}/skills/validate"
+  validate_body="$(jq -cn --arg repository "${REPO_URL}" '{repository: $repository}')"
+  validate_out="$(curl -sS -X POST "${API}/skills/validate" \
+    -H 'Content-Type: application/json' \
+    -d "${validate_body}" \
+    -w '\n%{http_code}')"
+  validate_code="$(tail -n1 <<<"${validate_out}")"
+  if [[ "${validate_code}" != 2* ]]; then
+    echo "Registry could not read ${REPO_URL} (HTTP ${validate_code})." >&2
+    echo "This usually means the repository is not publicly readable yet." >&2
+    sed '$d' <<<"${validate_out}" >&2
+    exit 1
+  fi
+fi
+
+failures=0
+for skill_dir in "${skill_dirs[@]}"; do
+  skill_md="${skill_dir}/SKILL.md"
+  [[ -f "${skill_md}" ]] || continue
+  name="$(basename "${skill_dir}")"
+  skill_path="skills/${name}/SKILL.md"
+
+  payload="$(jq -cn \
+    --arg repository "${REPO_URL}" \
+    --arg skillPath "${skill_path}" \
+    --arg agent "${AGENT_ID}" \
+    '{repository: $repository, skillPath: $skillPath, submissionSource: "agent", submittedByAgent: $agent}')"
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    # Assert the payload carries what the API documents as required, so a dry run
+    # catches a malformed request instead of deferring it to the real submission.
+    if ! jq -e '(.repository | length > 0) and (.skillPath | length > 0)' >/dev/null <<<"${payload}"; then
+      echo "DRY RUN: payload for ${name} is missing required fields." >&2
+      failures=$((failures + 1))
+      continue
+    fi
+    echo "DRY RUN ${name}: POST ${API}/skills/submit"
+    jq . <<<"${payload}"
+    continue
+  fi
+
+  echo "Submitting ${name}"
+  response="$(curl -sS -X POST "${API}/skills/submit" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}" \
+    -w '\n%{http_code}')"
+  code="$(tail -n1 <<<"${response}")"
+  body="$(sed '$d' <<<"${response}")"
+
+  status="submitted"
+  if [[ "${code}" != 2* ]]; then
+    # Re-submitting an existing skill is the expected steady state on every release
+    # after the first, so treat it as success rather than failing the workflow.
+    if grep -qiE 'already|duplicate|exists' <<<"${body}"; then
+      status="already-listed"
+      echo "  ${name}: already listed, nothing to do."
+    else
+      echo "  ${name}: submission failed (HTTP ${code})." >&2
+      echo "  ${body}" >&2
+      failures=$((failures + 1))
+      continue
+    fi
+  fi
+
+  if [[ -n "${RECEIPTS}" ]]; then
+    jq -cn \
+      --arg registry "openagentskill" \
+      --arg skill "${name}" \
+      --arg status "${status}" \
+      --argjson response "$(jq -c '.' <<<"${body}" 2>/dev/null || echo '{}')" \
+      '{registry: $registry, skill: $skill, status: $status, response: $response}' \
+      >>"${RECEIPTS}"
+  fi
+
+  # The status token is the only way to poll this submission later, but it is
+  # private -- keep it out of logs and let the caller archive the receipts file.
+  jq -r '"  " + (.submission.status // "submitted") + " id=" + (.submission.id // "unknown")' \
+    <<<"${body}" 2>/dev/null || true
+done
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "openagentskill: ${failures} skill(s) failed." >&2
+  exit 1
+fi
+
+echo "openagentskill: done ($([[ "${DRY_RUN}" -eq 1 ]] && echo "dry run" || echo "submitted"))."

--- a/scripts/publish-upskill.sh
+++ b/scripts/publish-upskill.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Submit every skill under skills/ to upskill (Autoloops).
+#
+# Called by .github/workflows/publish-registries.yml, and runnable by hand for
+# debugging.
+#
+# Docs: https://github.com/Autoloops/upskill
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_URL=""
+REF="main"
+RECEIPTS=""
+DRY_RUN=0
+CONFIG_PATH="${UPSKILL_CONFIG:-${HOME}/.config/upskill/config.json}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: publish-upskill.sh --repo-url URL [options]
+
+  --repo-url URL     Public GitHub URL of this repository (required).
+  --ref REF          Branch or tag the submitted tree URLs point at. Default: main
+  --receipts FILE    Append one JSON receipt per skill to FILE.
+  --dry-run          Render the submissions; make no network calls.
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-url) REPO_URL="${2:?--repo-url needs a value}"; shift 2 ;;
+    --ref) REF="${2:?--ref needs a value}"; shift 2 ;;
+    --receipts) RECEIPTS="${2:?--receipts needs a value}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+[[ -n "${REPO_URL}" ]] || { echo "--repo-url is required." >&2; usage; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required." >&2; exit 3; }
+
+mapfile -t skill_dirs < <(find "${ROOT}/skills" -mindepth 1 -maxdepth 1 -type d | sort)
+[[ "${#skill_dirs[@]}" -gt 0 ]] || { echo "No skills found under skills/." >&2; exit 1; }
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  command -v upskill >/dev/null 2>&1 || {
+    echo "upskill not found on PATH. Install with: npm install -g @autoloops/upskill" >&2
+    exit 3
+  }
+
+  upskill install
+  # Submissions are disabled by default, and `upskill submit` exits 0 while doing
+  # nothing when they are off. Without this the workflow reports a successful
+  # publish that never happened, so verify the setting actually took effect.
+  upskill config set submissions true
+
+  if [[ -f "${CONFIG_PATH}" ]]; then
+    if ! jq -e '.submissions == true' >/dev/null "${CONFIG_PATH}"; then
+      echo "upskill submissions are still disabled in ${CONFIG_PATH}; refusing to" >&2
+      echo "continue, because submit would silently no-op." >&2
+      exit 1
+    fi
+    echo "Verified submissions are enabled in ${CONFIG_PATH}."
+  else
+    echo "::warning::Could not find ${CONFIG_PATH} to confirm submissions are enabled."
+    echo "::warning::Treat this run's upskill results as unconfirmed and check the listing by hand."
+  fi
+fi
+
+failures=0
+for skill_dir in "${skill_dirs[@]}"; do
+  [[ -f "${skill_dir}/SKILL.md" ]] || continue
+  name="$(basename "${skill_dir}")"
+  # Submit a branch URL rather than the release tag so the listing tracks later
+  # updates instead of pinning to one release.
+  target="${REPO_URL}/tree/${REF}/skills/${name}"
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "DRY RUN ${name}: upskill submit ${target}"
+    continue
+  fi
+
+  echo "Submitting ${name}"
+  status="submitted"
+  if ! upskill submit "${target}"; then
+    echo "  ${name}: upskill submit failed." >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if [[ -n "${RECEIPTS}" ]]; then
+    jq -cn \
+      --arg registry "upskill" \
+      --arg skill "${name}" \
+      --arg status "${status}" \
+      --arg target "${target}" \
+      '{registry: $registry, skill: $skill, status: $status, target: $target}' \
+      >>"${RECEIPTS}"
+  fi
+done
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "upskill: ${failures} skill(s) failed." >&2
+  exit 1
+fi
+
+echo "upskill: done ($([[ "${DRY_RUN}" -eq 1 ]] && echo "dry run" || echo "submitted"))."

--- a/scripts/validate-skill.sh
+++ b/scripts/validate-skill.sh
@@ -35,8 +35,10 @@ if ! command -v skill-validator >/dev/null 2>&1; then
   exit 3
 fi
 
+# No --allow-extra-frontmatter: the Agent Skills spec allows only six frontmatter
+# keys, so an unexpected key must surface here rather than being waived.
 exec skill-validator check \
   "${strict_flag[@]}" \
-  --allow-flat-layouts --allow-extra-frontmatter \
+  --allow-flat-layouts \
   "${extra_args[@]}" \
   "${SKILL_DIR}/"

--- a/scripts/validate-spec.sh
+++ b/scripts/validate-spec.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Check every skill under skills/ against the Agent Skills specification using the
+# official reference validator (agentskills/agentskills, skills-ref).
+#
+# This is deliberately separate from scripts/validate-skill.sh: that script runs a
+# third-party linter whose checks are a superset of the spec (links, token counts,
+# file layout). This one answers only "does the frontmatter conform to the standard",
+# which is what registries validate against.
+#
+# Keep SKILLS_REF_REF in sync with .github/workflows/spec-conformance.yml.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILLS_DIR="${ROOT}/skills"
+SKILLS_REF_REF="69ef37e9424c0a7ea9dd2293b559e43ec8176379"
+
+if ! command -v skills-ref >/dev/null 2>&1; then
+  cat >&2 <<EOF
+skills-ref not found on PATH. It has no PyPI release, so install it from source
+(requires Python 3.11+):
+
+  python3 -m venv .venv && . .venv/bin/activate
+  pip install "git+https://github.com/agentskills/agentskills.git@${SKILLS_REF_REF}#subdirectory=skills-ref"
+
+EOF
+  exit 3
+fi
+
+# skills-ref validates one directory per invocation, so loop and aggregate rather
+# than exiting on the first failure -- one run should report every problem.
+failed=()
+checked=0
+for skill_dir in "${SKILLS_DIR}"/*/; do
+  [[ -f "${skill_dir}SKILL.md" ]] || continue
+  checked=$((checked + 1))
+  if ! skills-ref validate "${skill_dir%/}"; then
+    failed+=("$(basename "${skill_dir%/}")")
+  fi
+done
+
+if [[ "${checked}" -eq 0 ]]; then
+  echo "No skills found under ${SKILLS_DIR}/ -- expected at least one SKILL.md." >&2
+  exit 1
+fi
+
+if [[ "${#failed[@]}" -gt 0 ]]; then
+  echo >&2
+  echo "Spec conformance failed for ${#failed[@]} of ${checked} skill(s): ${failed[*]}" >&2
+  echo "The spec allows only these frontmatter keys: name, description, license," >&2
+  echo "compatibility, metadata, allowed-tools. Put anything else under metadata." >&2
+  echo "See https://agentskills.io/specification" >&2
+  exit 1
+fi
+
+echo "All ${checked} skill(s) conform to the Agent Skills specification."

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Aerospike",
+      "description": "Agent skills for the Aerospike core database: local setup, application development, and design-time data modeling. Core database only, not Aerospike Graph.",
+      "skills": [
+        "aerospike-getting-started",
+        "aerospike-development",
+        "aerospike-data-modeling"
+      ]
+    }
+  ]
+}

--- a/skills/aerospike-data-modeling/SKILL.md
+++ b/skills/aerospike-data-modeling/SKILL.md
@@ -9,7 +9,9 @@ description: >-
   reviewing client code against a model that already exists, or for client APIs,
   policies, CDT operations, and expression usage, use aerospike-development
   instead. Core database only; not Aerospike Graph.
-last_verified: 2026-08-06
+license: Apache-2.0
+metadata:
+  last_verified: "2026-08-06"
 ---
 
 # Aerospike: data model design

--- a/skills/aerospike-development/SKILL.md
+++ b/skills/aerospike-development/SKILL.md
@@ -9,7 +9,9 @@ description: >-
   aerospike-data-modeling instead. Redirect cluster deployment sizing
   XDR and backup questions to Aerospike Operations documentation. Core
   database only; not Aerospike Graph.
-last_verified: 2026-04-21
+license: Apache-2.0
+metadata:
+  last_verified: "2026-04-21"
 ---
 
 # Aerospike: application development

--- a/skills/aerospike-getting-started/SKILL.md
+++ b/skills/aerospike-getting-started/SKILL.md
@@ -9,7 +9,9 @@ description: >-
   Aerospike, replaces Redis or Memcached, builds feature stores or user-profile
   caches, or needs Aerospike client connectivity and correct defaults. Core
   database only (not Aerospike Graph).
-last_verified: 2026-04-21
+license: Apache-2.0
+metadata:
+  last_verified: "2026-04-21"
 ---
 
 # Aerospike Database: getting started


### PR DESCRIPTION
Covers steps 1 and 3 of [AIE-13](https://aerospike.atlassian.net/browse/AIE-13): conform to the Agent Skills standard, wire the check into CI, and automate registry publishing. Nothing is published by this PR — the publisher is merged inert.

## Summary

- **Fixed one real conformance gap.** All three skills carried a top-level `last_verified`, which the official `skills-ref` validator rejects: the spec permits only `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`. Moved under `metadata` (quoted, so it stays a string rather than parsing to a YAML date) and added `license: Apache-2.0`.
- **Closed the hole that hid it.** `validate-skill.sh` passed `--allow-extra-frontmatter`, which downgrades that error to a warning in the third-party linter. Dropped, so an unexpected key can't pass silently again.
- **Added a real conformance gate.** `scripts/validate-spec.sh` and `spec-conformance.yml` run the *official* validator, separate from `skill-validator` on purpose — that tool checks links, token counts, and layout beyond the spec, so passing it never implied conformance.
- **Automated publishing on release**, held behind four gates, so the first listing and every refresh run the same reviewed code.

## Research findings that change the ticket

Two of the five registries named in AIE-13 don't work as written, and the acceptance criteria need adjusting:

- **`agentskills.io` is not a registry.** It hosts the specification. Its [CONTRIBUTING.md](https://github.com/agentskills/agentskills/blob/main/CONTRIBUTING.md) says "We don't maintain a directory of community skills," and `/submit`, `/registry`, `/skills` all 404.
- **`skills.sh` has no submission path.** Vercel indexes only anonymous install telemetry from `npx skills add`. Advice to open a PR against `vercel-labs/skills` is wrong — the issue asking exactly that ([#880](https://github.com/vercel-labs/skills/issues/880)) is open and unanswered.
- **The spec requires no repo-root manifest**, so the ticket's "any manifest / index file the spec requires" resolves to nothing.

Targets are therefore **openagentskill.com** and **upskill**, both automatable. skills.sh is best-effort via `skills.sh.json` and a documented install line.

## The four gates

| Gate | Mechanism | Why |
|---|---|---|
| Conformance | `needs:` on both check workflows | A PR run doesn't prove the tag is clean |
| Visibility | `gh api ... --jq .visibility` must be `public` | A submitted URL that 404s wastes our one credible shot at that registry |
| Kill switch | `REGISTRY_PUBLISH_ENABLED` variable must be `true` | The hold, and the rollback |
| Approval | `registries` environment, required reviewers | Neither registry documents a delete endpoint, so this one is permanent |

Visibility and kill-switch failures skip with a notice rather than failing, so a release cut during the hold isn't a red build. A `dry_run` input defaults to `true` and renders payloads with no registry contact, which is what makes the hold period useful.

## Two traps handled explicitly

Both would otherwise produce a green build that published nothing:

- `upskill submit` **exits 0 while doing nothing** when submissions are disabled, which is the default. The script sets the flag and then verifies it landed in the config.
- openagentskill's status tokens are the only way to poll a submission later. They're private, so they go to an artifact rather than the logs or job summary.

One subtlety in dry-run: it deliberately stops short of openagentskill's `/validate` endpoint, which reads `SKILL.md` over the public URL. Calling it while the repo is internal would report a failure that looks like a bug here rather than the expected state.

## Test plan

Everything below was run locally against this branch.

- [x] `skills-ref validate` passes on all three skills; **negative test** confirms a top-level `last_verified` or `version` still fails with exit 1, so the gate has teeth
- [x] `./scripts/validate-spec.sh` passes (3/3)
- [x] `./scripts/validate-skill.sh` produces **no new** warnings — the single token-footprint warning is byte-identical on unmodified `main`, and `--ci` mode exits 2, which the workflow treats as success
- [x] `compile-agents.py --shape stripped --check` reports no drift
- [x] `actionlint` clean on all five workflows, with `shellcheck` on PATH for the inline shell
- [x] `shellcheck` clean on all `scripts/*.sh`
- [x] Both publisher scripts dry-run successfully and make no network calls
- [x] `skills.sh.json` validates and its `$schema` URL returns 200
- [x] No sensitive files tracked; `eval/` and `results/` now ignored

## Follow-ups (not in this PR)

- Open-source sign-off and the flip to public — the remaining blocker on AIE-13
- Branch topology: `origin/HEAD` points at `init` while the default branch is `main`, and workflows still trigger on `init`/`master`
- Going live: create the `registries` environment with reviewers, set `REGISTRY_PUBLISH_ENABLED=true`, cut a release. See [`docs/PUBLISHING.md`](docs/PUBLISHING.md)

[AIE-13]: https://aerospike.atlassian.net/browse/AIE-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ