### PR TITLE
feat: publish one compiled skill with pre-publish checks (AIE-13, AIE-16)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 For a short overview and read order, see [`AGENTS.md`](../AGENTS.md) at the repository root and the skill index [`skills/README.md`](../skills/README.md).
 
-**Fast path:** the published rules for all skills are compiled into [`compiled-skills/SKILLS.md`](../compiled-skills/SKILLS.md).
+**Fast path:** the published rules for all skills are compiled into [`compiled-skills/aerospike/SKILL.md`](../compiled-skills/aerospike/SKILL.md).
 
 When the user’s task involves **Aerospike Database**, route as follows:
 

--- a/.github/workflows/compile-agents.yml
+++ b/.github/workflows/compile-agents.yml
@@ -19,6 +19,8 @@ on:
       - "scripts/compile-agents.py"
       - "scripts/skills_compile/**"
       - ".github/workflows/compile-agents.yml"
+  # Called by publish-registries.yml so a release cannot publish a stale artifact.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -1,0 +1,202 @@
+# Publish the compiled skill (compiled-skills/aerospike) to agent-skill registries on release.
+#
+# This is the only path that contacts a registry. One skill is submitted: the artifact
+# compiled from the three authoring folders under skills/. The first listing and every
+# later refresh run the same reviewed code. It is merged inert and held behind four
+# independent gates; see docs/PUBLISHING.md for the operator's view.
+#
+#   1. Conformance  - the spec-conformance, skill-validator, and compile-agents
+#                     workflows must pass. The last one fails on a stale artifact,
+#                     so a release cannot submit output that lags its sources.
+#   2. Visibility   - the repository must be public, or a submitted URL would 404.
+#   3. Kill switch  - repository variable REGISTRY_PUBLISH_ENABLED must be "true".
+#   4. Approval     - the publish job runs in the "registries" environment, which
+#                     requires a reviewer. Neither registry documents a way to
+#                     delete a submission, so this gate is permanent, not just a
+#                     safeguard for the initial rollout.
+#
+# Gates 2 and 3 skip with a notice rather than failing: a release cut during the
+# hold period should not report a broken build.
+name: publish-registries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Render payloads without contacting any registry"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never let two releases submit concurrently; registries dedupe on their side but
+  # interleaved receipts would make it impossible to tell what was published.
+  group: publish-registries
+  cancel-in-progress: false
+
+jobs:
+  gate-spec:
+    uses: ./.github/workflows/spec-conformance.yml
+
+  gate-lint:
+    uses: ./.github/workflows/skill-validator.yml
+
+  gate-compiled:
+    uses: ./.github/workflows/compile-agents.yml
+
+  preflight:
+    needs: [gate-spec, gate-lint, gate-compiled]
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.decide.outputs.mode }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Decide publish mode
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # On a release there is no dry_run input, so the intent is a real publish.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          PUBLISH_ENABLED: ${{ vars.REGISTRY_PUBLISH_ENABLED }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "mode=dry-run" >> "$GITHUB_OUTPUT"
+            echo "Dry run requested: payloads will be rendered, no registry contacted."
+            exit 0
+          fi
+
+          visibility="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.visibility' | tr '[:upper:]' '[:lower:]')"
+          if [[ "${visibility}" != "public" ]]; then
+            echo "mode=blocked" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Publishing skipped::Repository is ${visibility}, not public. Registries require a public URL, so nothing was submitted."
+            exit 0
+          fi
+
+          if [[ "${PUBLISH_ENABLED}" != "true" ]]; then
+            echo "mode=held" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Publishing held::Repository variable REGISTRY_PUBLISH_ENABLED is not \"true\". Set it to go live; see docs/PUBLISHING.md."
+            exit 0
+          fi
+
+          echo "mode=publish" >> "$GITHUB_OUTPUT"
+          echo "All gates passed; publishing pends reviewer approval of the registries environment."
+
+  dry-run:
+    needs: preflight
+    if: needs.preflight.outputs.mode == 'dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # No registry is contacted here, including openagentskill's /validate endpoint,
+      # which reads SKILL.md over the public URL and so cannot work while the
+      # repository is internal. Calling it would report a failure that looks like a
+      # bug in this workflow rather than the expected state.
+      - name: Render payloads
+        run: |
+          set -euo pipefail
+          repo_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+
+          # Each script runs before anything is written to the summary so a failure
+          # surfaces as a failed step rather than being swallowed by a pipeline.
+          ./scripts/publish-openagentskill.sh --repo-url "${repo_url}" --dry-run | tee oas.txt
+          ./scripts/publish-upskill.sh --repo-url "${repo_url}" --dry-run | tee upskill.txt
+
+          {
+            echo "## Registry publish dry run"
+            echo
+            echo "No registry was contacted. Repository URL: \`${repo_url}\`"
+            echo
+            echo '### openagentskill'
+            echo '```json'
+            cat oas.txt
+            echo '```'
+            echo '### upskill'
+            echo '```'
+            cat upskill.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    needs: preflight
+    if: needs.preflight.outputs.mode == 'publish'
+    runs-on: ubuntu-latest
+    # Holds the job pending until a reviewer approves. Configure required reviewers
+    # on this environment, or the gate is decorative.
+    environment: registries
+    env:
+      UPSKILL_VERSION: 0.10.1
+      # Submitted tree URLs point at the default branch, not the release tag, so a
+      # listing keeps tracking updates instead of freezing at one release.
+      PUBLISH_REF: main
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Submit to openagentskill
+        run: |
+          ./scripts/publish-openagentskill.sh \
+            --repo-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --agent-id "aerospike-agent-skills-ci" \
+            --receipts receipts.jsonl
+
+      - name: Submit to upskill
+        run: |
+          # Pinned rather than floating: a CLI that no-ops when misconfigured is not
+          # one to auto-upgrade underneath us.
+          npm install -g "@autoloops/upskill@${UPSKILL_VERSION}"
+          ./scripts/publish-upskill.sh \
+            --repo-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --ref "${PUBLISH_REF}" \
+            --receipts receipts.jsonl
+
+      - name: Summarize submissions
+        if: always()
+        run: |
+          {
+            echo "## Registry submissions"
+            echo
+            if [[ -s receipts.jsonl ]]; then
+              echo "| Registry | Skill | Status |"
+              echo "|---|---|---|"
+              jq -r '"| " + .registry + " | " + .skill + " | " + .status + " |"' receipts.jsonl
+              echo
+              echo "Submission ids and status tokens are in the \`registry-receipts\` artifact."
+              echo "Transcribe them into \`docs/PUBLISHING.md\`; a token is the only way to poll a submission later."
+            else
+              echo "No receipts were written."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Receipts carry private status tokens, so they are archived rather than logged.
+      - name: Upload receipts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: registry-receipts
+          path: receipts.jsonl
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/skill-validator.yml
+++ b/.github/workflows/skill-validator.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - "skills/**"
+      - "compiled-skills/**"
       - ".github/workflows/skill-validator.yml"
       - "scripts/validate-skill.sh"
   push:
@@ -15,8 +16,12 @@ on:
       - init
     paths:
       - "skills/**"
+      - "compiled-skills/**"
       - ".github/workflows/skill-validator.yml"
       - "scripts/validate-skill.sh"
+  # Called by publish-registries.yml so a release cannot publish a tree with
+  # broken links or oversized references.
+  workflow_call:
 
 env:
   SKILL_VALIDATOR_VERSION: v1.5.5
@@ -59,9 +64,10 @@ jobs:
           {
             echo "## skill-validator"
             set +e
-            skill-validator check \
-              --allow-flat-layouts --allow-extra-frontmatter \
-              -o markdown skills/
+            # Via the script, not a direct call: it owns the root list and the
+            # compiled-skills link-skip, and `skill-validator check` takes exactly
+            # one path, so a second root here is rejected rather than validated.
+            ./scripts/validate-skill.sh --summary
             sum=$?
             set -e
             [[ "$sum" -eq 0 || "$sum" -eq 2 ]] || exit "$sum"

--- a/.github/workflows/spec-conformance.yml
+++ b/.github/workflows/spec-conformance.yml
@@ -1,0 +1,75 @@
+# Validates skills/ against the Agent Skills specification with the official
+# reference validator (agentskills/agentskills, skills-ref).
+#
+# This runs alongside skill-validator.yml on purpose. That workflow is a third-party
+# linter whose checks exceed the spec (links, token counts, layout); this one measures
+# conformance to the standard itself, which is what registries validate against.
+# Registry publishing (publish-registries.yml) gates on this job.
+#
+# Keep SKILLS_REF_REF in sync with scripts/validate-spec.sh.
+name: spec-conformance
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "compiled-skills/**"
+      - "scripts/validate-spec.sh"
+      - ".github/workflows/spec-conformance.yml"
+  push:
+    branches: [main, master, init]
+    paths:
+      - "skills/**"
+      - "compiled-skills/**"
+      - "scripts/validate-spec.sh"
+      - ".github/workflows/spec-conformance.yml"
+  # Called by publish-registries.yml so a release cannot publish a nonconformant tree.
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    env:
+      # skills-ref has no PyPI release, so it is installed from a pinned commit.
+      SKILLS_REF_REF: 69ef37e9424c0a7ea9dd2293b559e43ec8176379
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          # skills-ref requires >=3.11.
+          python-version: "3.12"
+
+      - name: Install skills-ref (official reference validator)
+        run: |
+          pip install \
+            "git+https://github.com/agentskills/agentskills.git@${SKILLS_REF_REF}#subdirectory=skills-ref"
+
+      - name: Validate skills against the spec
+        run: ./scripts/validate-spec.sh
+
+      - name: Append skill properties to job summary
+        if: always()
+        run: |
+          {
+            echo "## Agent Skills spec conformance"
+            echo
+            echo "Validator: \`skills-ref\` @ \`${SKILLS_REF_REF}\`"
+            echo
+            for skill_dir in skills/*/ compiled-skills/aerospike/; do
+              [ -f "${skill_dir}SKILL.md" ] || continue
+              echo "### ${skill_dir%/}"
+              echo '```json'
+              skills-ref read-properties "${skill_dir%/}" || echo '{"error": "could not read properties"}'
+              echo '```'
+              echo
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+# Run the unit test suite.
+# Fails if compiler, publish-script, or documentation-guard tests fail.
+name: tests
+
+on:
+  pull_request:
+    paths:
+      - "tests/**"
+      - "scripts/**"
+      - "pytest.ini"
+      - "skills.sh.json"
+      - "compiled-skills/**"
+      - "*.md"
+      - ".github/copilot-instructions.md"
+      - ".github/workflows/tests.yml"
+  push:
+    branches: [init, main, master]
+    paths:
+      - "tests/**"
+      - "scripts/**"
+      - "pytest.ini"
+      - "skills.sh.json"
+      - "compiled-skills/**"
+      - "*.md"
+      - ".github/copilot-instructions.md"
+      - ".github/workflows/tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r scripts/requirements-compile.txt -r scripts/requirements-test.txt
+      - name: Run unit tests
+        run: python3 -m pytest tests/unit -v

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,18 @@
 
 __pycache__/
 .idea/
+
+# Local eval harness working tree. The harness itself lives in a separate repo;
+# these hold API keys and raw model output that must never reach this repository.
+eval/
+results/
+.env
+.env.*
+!.env.example
+
+# Local virtualenv for skills-ref, which has no PyPI release.
+.venv/
+
+# Agent scratch space (briefs, reports, session notes).
+.superpowers/
+agent_api_key.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Apply when the user (or task) involves **Aerospike**, **Docker-based Aerospike**
 
 ## Read order
 
-**Fast path:** [`compiled-skills/SKILLS.md`](compiled-skills/SKILLS.md) — published rules for the getting-started, development, and data-modeling skills in one file, updated on every merge to `main`. [Install guide](compiled-skills/README.md).
+**Fast path:** [`compiled-skills/aerospike/SKILL.md`](compiled-skills/aerospike/SKILL.md) — published rules for the getting-started, development, and data-modeling skills in one file, updated on every merge to `main`. [Install guide](compiled-skills/README.md).
 
 **More detail** (optional, under `skills/`):
 
@@ -27,7 +27,7 @@ Apply when the user (or task) involves **Aerospike**, **Docker-based Aerospike**
 3. **Application development:** [`skills/aerospike-development/SKILL.md`](skills/aerospike-development/SKILL.md) → [`skills/aerospike-development/references/README.md`](skills/aerospike-development/references/README.md) → [`skills/aerospike-development/reference.md`](skills/aerospike-development/reference.md) / [`skills/aerospike-development/examples.md`](skills/aerospike-development/examples.md) as needed.
 4. **Design-time data modeling:** [`skills/aerospike-data-modeling/SKILL.md`](skills/aerospike-data-modeling/SKILL.md) → [`skills/aerospike-data-modeling/references/`](skills/aerospike-data-modeling/references/) → [`skills/aerospike-data-modeling/reference.md`](skills/aerospike-data-modeling/reference.md) as needed.
 
-Do not invent REST APIs, SQL DDL, or wrong package names; follow the blacklist in [`skills/aerospike-getting-started/SKILL.md`](skills/aerospike-getting-started/SKILL.md) / [`compiled-skills/SKILLS.md`](compiled-skills/SKILLS.md).
+Do not invent REST APIs, SQL DDL, or wrong package names; follow the blacklist in [`skills/aerospike-getting-started/SKILL.md`](skills/aerospike-getting-started/SKILL.md) / [`compiled-skills/aerospike/SKILL.md`](compiled-skills/aerospike/SKILL.md).
 
 ## Humans
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Start with [`AGENTS.md`](AGENTS.md) for routing and read order across skills.
 
-**Fast path:** [`compiled-skills/SKILLS.md`](compiled-skills/SKILLS.md) carries the published rules for every skill in one file.
+**Fast path:** [`compiled-skills/aerospike/SKILL.md`](compiled-skills/aerospike/SKILL.md) carries the published rules for every skill in one file.
 
 Then open the skill that matches the task:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for helping improve this repository. It holds **Agent Skills** under [`sk
 
 ## Adding a new skill (especially Aerospike)
 
-1. Create `skills/<skill-name>/` with a required `SKILL.md` at the skill root. YAML **`name`** must match the parent folder name; **`description`** explains what and when; optional **`last_verified`** after you validate facts. For frontmatter shape, see an existing skill such as [`skills/aerospike-getting-started/SKILL.md`](skills/aerospike-getting-started/SKILL.md).
+1. Create `skills/<skill-name>/` with a required `SKILL.md` at the skill root. YAML **`name`** must match the parent folder name; **`description`** explains what and when; optional **`metadata.last_verified`** after you validate facts. For frontmatter shape, see an existing skill such as [`skills/aerospike-getting-started/SKILL.md`](skills/aerospike-getting-started/SKILL.md).
 2. Add any companion files inside that folder only (skill markdown must not link outside the skill directory—see validator note below).
 3. Run [`./scripts/validate-skill.sh`](scripts/validate-skill.sh) from the repo root and fix reported issues.
 4. Update [`skills/README.md`](skills/README.md) with a table row linking to the new `SKILL.md`.
@@ -35,7 +35,8 @@ Thanks for helping improve this repository. It holds **Agent Skills** under [`sk
 | Aerospike Compose, custom config, editions, platform notes | [skills/aerospike-getting-started/reference.md](skills/aerospike-getting-started/reference.md) |
 | Aerospike app development rules, examples TOC | [skills/aerospike-development/references/README.md](skills/aerospike-development/references/README.md), [skills/aerospike-development/examples.md](skills/aerospike-development/examples.md) |
 | Tool-agnostic AI entry (read order, scope) | [AGENTS.md](AGENTS.md) |
-| Compiled published rules (auto-generated from skills) | [compiled-skills/SKILLS.md](compiled-skills/SKILLS.md) |
+| Compiled published skill (auto-generated body; do not hand-edit) | [compiled-skills/aerospike/SKILL.md](compiled-skills/aerospike/SKILL.md) |
+| Published skill frontmatter (hand-written) | [scripts/skills_compile/published_skill.yaml](scripts/skills_compile/published_skill.yaml) |
 | GitHub Copilot repo instructions | [.github/copilot-instructions.md](.github/copilot-instructions.md) |
 | Human install path, checklist | [README.md](README.md) |
 
@@ -45,9 +46,28 @@ Thanks for helping improve this repository. It holds **Agent Skills** under [`sk
 
 ## Skill frontmatter (`SKILL.md`)
 
-- **`name`:** Lowercase letters, numbers, hyphens; max 64 characters; must match the parent folder name.
-- **`description`:** Third person; include **what** the skill does and **when** to use it (trigger phrases). Stay under **1024** characters.
-- **`last_verified` (optional):** Bump this **ISO date** when you change commands, images, or product facts for **that skill**—after you have manually re-checked the documented flow.
+The [Agent Skills specification](https://agentskills.io/specification) defines a **closed** set of six frontmatter keys. Only these are allowed in a `SKILL.md`, and the official validator rejects anything else:
+
+`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`
+
+- **`name`:** Lowercase letters, numbers, hyphens; 1–64 characters; no leading, trailing, or consecutive hyphens; must match the parent folder name.
+- **`description`:** Third person; include **what** the skill does and **when** to use it (trigger phrases). 1–1024 characters.
+- **`license` (optional):** `Apache-2.0` for skills in this repository, matching [LICENSE](LICENSE). Registries factor license clarity into trust scoring.
+- **`metadata` (optional):** The spec's extension point—a map of string keys to **string** values. Anything not in the six keys above belongs here.
+- **`metadata.last_verified`:** Bump this **ISO date** when you change commands, images, or product facts for **that skill**—after you have manually re-checked the documented flow. **Quote it** (`"2026-04-21"`), because an unquoted YAML date parses to a date object and `metadata` values must be strings.
+
+```yaml
+---
+name: aerospike-getting-started
+description: >-
+  What the skill does, and when an agent should reach for it.
+license: Apache-2.0
+metadata:
+  last_verified: "2026-04-21"
+---
+```
+
+This closed key set applies to `SKILL.md` only. Companion files under `references/` are not skill manifests, so their frontmatter is free-form.
 
 ## Validate the skill package (skill-validator)
 
@@ -73,20 +93,39 @@ CI runs [agent-ecosystem/skill-validator](https://github.com/agent-ecosystem/ski
    - **Raw one-liner** (strict, same as local script default):
 
      ```bash
-     skill-validator check --strict --allow-flat-layouts --allow-extra-frontmatter skills/
+     skill-validator check --strict --allow-flat-layouts skills/
      ```
+
+   `--allow-flat-layouts` is intentional: `examples.md` and `reference.md` beside `SKILL.md` are spec-legal, and only this third-party tool objects to them. There is deliberately **no** `--allow-extra-frontmatter`, so an unexpected frontmatter key fails here instead of being waived.
 
    Optional: [Homebrew install](https://github.com/agent-ecosystem/skill-validator#install-cli) (`brew tap agent-ecosystem/tap && brew install skill-validator`) if you prefer not to use `go install`.
 
 **Note:** Skill markdown must not link **outside** the skill directory (e.g. no `../README.md`); describe repo-level files in prose instead.
 
+## Check spec conformance (skills-ref)
+
+Registries validate against the [Agent Skills specification](https://agentskills.io/specification), so this check is separate from the linter above: it answers only "does this frontmatter conform to the standard." CI runs it via [`.github/workflows/spec-conformance.yml`](.github/workflows/spec-conformance.yml).
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate   # requires Python 3.11+
+pip install "git+https://github.com/agentskills/agentskills.git@69ef37e9424c0a7ea9dd2293b559e43ec8176379#subdirectory=skills-ref"
+./scripts/validate-spec.sh
+```
+
+The commit is pinned because `skills-ref` has no PyPI release. Keep the pin in [`scripts/validate-spec.sh`](scripts/validate-spec.sh) and the workflow in sync.
+
+## Publishing to registries
+
+Submission is automated on release and gated behind conformance, public visibility, a kill-switch variable, and reviewer approval. Do not submit by hand—see [`docs/PUBLISHING.md`](docs/PUBLISHING.md).
+
 ## Before you open a pull request
 
 1. **Fact-check** any product behavior you document against current **official** docs or release notes for that product—not only blog posts or old threads.
-2. **Run** `./scripts/validate-skill.sh` (see above).
-3. **Exercise the skill** you changed: follow the happy path in `SKILL.md` (e.g. commands, containers, client smoke test) when the skill includes procedural steps.
-4. **If you changed `skills/`**, regenerate compiled output: `python scripts/compile-agents.py --write` (or let CI on `main` do it). PRs run a drift check — stale `compiled-skills/` fails CI.
-5. **Keep diffs focused**—one logical change per PR when possible (e.g. “fix port wording in Aerospike skill” vs mixing unrelated skills or refactors).
+2. **Run** `python3 -m pytest tests/unit -v` (see [tests/README.md](tests/README.md)).
+3. **Run** `./scripts/validate-skill.sh` (see above).
+4. **Exercise the skill** you changed: follow the happy path in `SKILL.md` (e.g. commands, containers, client smoke test) when the skill includes procedural steps.
+5. **If you changed `skills/` or [`scripts/skills_compile/published_skill.yaml`](scripts/skills_compile/published_skill.yaml)**, regenerate compiled output: `python scripts/compile-agents.py --write` (or let CI on `main` do it). PRs run a drift check — stale `compiled-skills/` fails CI.
+6. **Keep diffs focused**—one logical change per PR when possible (e.g. “fix port wording in Aerospike skill” vs mixing unrelated skills or refactors).
 
 For **Aerospike** changes specifically: verify ports, namespaces, TTL/NSUP, and image names against [Aerospike documentation](https://aerospike.com/docs/); run the Docker flow and at least **one** client example from [`examples.md`](skills/aerospike-getting-started/examples.md) for a stack you have installed. Avoid duplicating the full `aerospike.conf` in multiple files—keep one canonical copy in [`SKILL.md`](skills/aerospike-getting-started/SKILL.md) unless you have a strong reason.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository holds **Aerospike-related Agent Skills** under [`skills/`](skill
 
 The **canonical list of skills** (and what to copy) is [`skills/README.md`](skills/README.md). More Aerospike skills may appear there over time.
 
-**Layout note:** If you previously used `aerospike-getting-started/` at the **repository root**, it now lives at **`skills/aerospike-getting-started/`**. Copy from `skills/<skill-name>/` when installing into an agent.
+**Layout note:** If you previously used `aerospike-getting-started/` at the **repository root**, it now lives at **`skills/aerospike-getting-started/`**. That folder is for **contributors** who edit the skill sources; users install the compiled skill from [`compiled-skills/`](compiled-skills/README.md).
 
 ## Skills in this repository
 
@@ -40,7 +40,7 @@ The **canonical list of skills** (and what to copy) is [`skills/README.md`](skil
 | [skills/aerospike-development/examples.md](skills/aerospike-development/examples.md) | Additional examples for the development skill |
 | [skills/aerospike-data-modeling/SKILL.md](skills/aerospike-data-modeling/SKILL.md) | Data modeling skill: design-time workflow, mental model, pointers into references |
 | [AGENTS.md](AGENTS.md) | Short read order and routing for any AI assistant |
-| [compiled-skills/SKILLS.md](compiled-skills/SKILLS.md) | Published agent rules, compiled from `skills/` into one file |
+| [compiled-skills/aerospike/SKILL.md](compiled-skills/aerospike/SKILL.md) | Published agent skill, compiled from `skills/` into one file |
 | [.github/copilot-instructions.md](.github/copilot-instructions.md) | GitHub Copilot repository instructions |
 
 Skill packaging evaluation (structure A/B tests, coverage gates) lives in the separate [agent-skills-eval](https://github.com/citrusleaf/agent-skills-eval) repository.
@@ -49,25 +49,16 @@ The **canonical** `aerospike.conf` and commands for local setup live in [`skills
 
 ## Using with AI assistants
 
-Copy **one or more** folders from `skills/<skill-name>/` into your tool’s skills location. The directory name on disk must match the YAML `name` in that skill’s `SKILL.md` (for example `aerospike-getting-started` or `aerospike-development`).
+We publish **one** skill: [`compiled-skills/aerospike/SKILL.md`](compiled-skills/aerospike/SKILL.md), compiled from the three authoring folders under [`skills/`](skills/). Registries list that artifact only. The folders under `skills/` are maintained for editing and compilation, not as separate install targets.
 
 | Tool | What to do |
 |------|----------------|
-| **Any agent (recommended)** | Add [`compiled-skills/SKILLS.md`](compiled-skills/SKILLS.md) to always-on context. [Install guide](compiled-skills/README.md). Raw URL: `https://raw.githubusercontent.com/aerospike/agent-skills/main/compiled-skills/SKILLS.md` |
-| **Cursor (skill folders)** | Copy `skills/aerospike-getting-started`, `skills/aerospike-development`, and/or `skills/aerospike-data-modeling` to `<project>/.cursor/skills/<same-folder-name>/` (or `~/.cursor/skills/` for all projects). Restart Cursor. Each skill is discovered via its YAML `description` in `SKILL.md`. |
+| **Any agent (recommended)** | Add [`compiled-skills/aerospike/SKILL.md`](compiled-skills/aerospike/SKILL.md) to always-on context. [Install guide](compiled-skills/README.md). Raw URL: `https://raw.githubusercontent.com/aerospike/agent-skills/main/compiled-skills/aerospike/SKILL.md` |
+| **`skills` CLI (any supported agent)** | `npx skills add https://github.com/aerospike/agent-skills/tree/main/compiled-skills/aerospike` installs the published skill. Do not use the repository root URL — the CLI discovers `skills/` first and would install the uncompiled authoring folders. |
+| **Gemini CLI** | `npx skills add https://github.com/aerospike/agent-skills/tree/main/compiled-skills/aerospike -a gemini-cli` installs to `.agents/skills/aerospike/` (globally `~/.gemini/skills/`). |
 | **GitHub Copilot** | Uses [`.github/copilot-instructions.md`](.github/copilot-instructions.md) in supported clients; see also [AGENTS.md](AGENTS.md). |
-| **Claude Code / similar** | Open [CLAUDE.md](CLAUDE.md) and [AGENTS.md](AGENTS.md); for one file, use [`compiled-skills/SKILLS.md`](compiled-skills/SKILLS.md), or read skill bodies under `skills/*/`. |
-| **Other chats (Claude, ChatGPT, etc.)** | Upload or link [`compiled-skills/SKILLS.md`](compiled-skills/SKILLS.md), or add the skill folder(s) to a **project** / **knowledge** set. |
-
-## Install for Cursor (optional)
-
-1. Copy the entire folder for each skill you want—for example `skills/aerospike-getting-started` and/or `skills/aerospike-development`—into either location:
-   - **Project skills (recommended for sharing with a repo):**  
-     `<your-project>/.cursor/skills/<skill-folder-name>/`
-   - **Personal skills (all projects on this machine):**  
-     `~/.cursor/skills/<skill-folder-name>/`
-2. Restart Cursor or reload the window if a skill does not appear.
-3. In chat, describe your task (local Docker vs client modeling); the agent can match skills using each `SKILL.md` YAML `description`.
+| **Claude Code / similar** | Open [CLAUDE.md](CLAUDE.md) and [AGENTS.md](AGENTS.md); add [`compiled-skills/aerospike/SKILL.md`](compiled-skills/aerospike/SKILL.md) to project instructions or skills. |
+| **Other chats (Claude, ChatGPT, etc.)** | Upload or link [`compiled-skills/aerospike/SKILL.md`](compiled-skills/aerospike/SKILL.md). |
 
 ## Use without AI tools (any editor)
 
@@ -95,9 +86,11 @@ Use this when your goal is a **running local database** and a **verified first c
 
 ## Maintenance and distribution
 
-- **`last_verified`:** Each skill’s `SKILL.md` may include `last_verified`. When you change Docker images, client commands, or major facts for **that** skill, re-check the documented flow and update the date.
+- **`metadata.last_verified`:** Each skill’s `SKILL.md` may carry `last_verified` under `metadata`. When you change Docker images, client commands, or major facts for **that** skill, re-check the documented flow and update the date.
 - **Linting skills:** Run `./scripts/validate-skill.sh` (see [CONTRIBUTING.md](CONTRIBUTING.md#validate-the-skill-package-skill-validator)); CI runs the same check via [`.github/workflows/skill-validator.yml`](.github/workflows/skill-validator.yml).
-- **Compiled skills:** `compiled-skills/` is generated from `skills/`. After editing any skill, run `python3 scripts/compile-agents.py --write`; CI fails the PR if the compiled output is stale.
+- **Spec conformance:** Run `./scripts/validate-spec.sh` to check `SKILL.md` frontmatter against the [Agent Skills specification](https://agentskills.io/specification); CI runs it via [`.github/workflows/spec-conformance.yml`](.github/workflows/spec-conformance.yml).
+- **Publishing:** Registry submission is automated on release—see [`docs/PUBLISHING.md`](docs/PUBLISHING.md).
+- **Compiled skill:** `compiled-skills/` is generated from `skills/`. After editing any skill, run `python3 scripts/compile-agents.py --write`; CI fails the PR if the compiled output is stale. Frontmatter for the published skill lives in `scripts/skills_compile/published_skill.yaml`.
 - **Contributing:** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add or edit skills and keep root docs in sync.
 - **Redistribution:** This repository is licensed under the [Apache License 2.0](LICENSE), matching [aerospike/data-modeling-guide](https://github.com/aerospike/data-modeling-guide).
 

--- a/compiled-skills/README.md
+++ b/compiled-skills/README.md
@@ -1,30 +1,39 @@
-# Published Aerospike skills
+# Published Aerospike skill
 
-This directory holds the **published** Aerospike agent rules — one file you can add to any AI assistant. Content is built from [`skills/`](../skills/); CI fails any pull request whose compiled output is stale, so this file always matches the source skills on `main`.
+This directory holds the **published** Aerospike agent skill — one file compiled from the three authoring folders under [`skills/`](../skills/). CI fails any pull request whose compiled output is stale, so this always matches the source skills on `main`.
 
 | File | Purpose |
 |------|---------|
-| [`SKILLS.md`](SKILLS.md) | **Download this** — getting-started, application development, and data-modeling rules in one file |
+| [`aerospike/SKILL.md`](aerospike/SKILL.md) | **Download this** — getting-started, application development, and data-modeling rules in one file, with frontmatter registries can validate |
 
 ## Quick install
+
+**With the [`skills` CLI](https://skills.sh):**
+
+```bash
+npx skills add https://github.com/aerospike/agent-skills/tree/main/compiled-skills/aerospike
+```
 
 **Raw file URL (use `main` or a release tag):**
 
 ```
-https://raw.githubusercontent.com/aerospike/agent-skills/main/compiled-skills/SKILLS.md
+https://raw.githubusercontent.com/aerospike/agent-skills/main/compiled-skills/aerospike/SKILL.md
 ```
 
-1. Download [`SKILLS.md`](SKILLS.md) (or use the raw URL above).
-2. Add it to your agent's **always-on context** (project rules, system prompt, knowledge base, or repo instructions).
+1. Download [`aerospike/SKILL.md`](aerospike/SKILL.md) (or use the raw URL above).
+2. Add it to your agent's **always-on context** (project rules, system prompt, knowledge base, or repo instructions), or drop the `aerospike/` folder into your agent's skills directory.
 3. See [`AGENTS.md`](../AGENTS.md) for a short overview.
 
 ## By tool
 
 | Tool | What to do |
 |------|------------|
-| **Cursor** | Copy `compiled-skills/SKILLS.md` into a project rule (e.g. `.cursor/rules/aerospike.mdc`) or reference the raw URL in a rule. |
-| **GitHub Copilot** | This repo's [`.github/copilot-instructions.md`](../.github/copilot-instructions.md) already points at `SKILLS.md`. |
-| **Claude Code / similar** | Add `compiled-skills/SKILLS.md` to project instructions, or start from [`CLAUDE.md`](../CLAUDE.md). |
-| **ChatGPT / other chats** | Upload `SKILLS.md` to a project knowledge set, or paste the raw URL when working on Aerospike. |
+| **Claude Code** | `npx skills add https://github.com/aerospike/agent-skills/tree/main/compiled-skills/aerospike -a claude-code`, which installs to `.claude/skills/aerospike/`. Or add the file to project instructions. |
+| **Cursor** | `npx skills add https://github.com/aerospike/agent-skills/tree/main/compiled-skills/aerospike -a cursor`, which installs to `.agents/skills/aerospike/` (globally, `~/.cursor/skills/`). Or copy the file into a project rule such as `.cursor/rules/aerospike.mdc`. |
+| **Gemini CLI** | `npx skills add https://github.com/aerospike/agent-skills/tree/main/compiled-skills/aerospike -a gemini-cli`, which installs to `.agents/skills/aerospike/` (globally, `~/.gemini/skills/`). |
+| **GitHub Copilot** | This repo's [`.github/copilot-instructions.md`](../.github/copilot-instructions.md) already points at the compiled skill. |
+| **ChatGPT / other chats** | Upload `aerospike/SKILL.md` to a project knowledge set, or paste the raw URL when working on Aerospike. |
+
+The three folders under [`skills/`](../skills/) are the authoring source for this file. They are not published or installed separately — edit there, then recompile. See [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 For more install options, see the [repository README](../README.md#using-with-ai-assistants).

--- a/compiled-skills/aerospike/SKILL.md
+++ b/compiled-skills/aerospike/SKILL.md
@@ -1,4 +1,26 @@
-_Auto-generated from `skills/aerospike-getting-started`, `skills/aerospike-development`, `skills/aerospike-data-modeling`. Edit the skills under `skills/`, not this file._
+---
+name: aerospike
+description: >-
+  Work with the Aerospike core database end to end: run a local instance with
+  Docker and verify a first write and read, build or review client code with the
+  official SDKs (Python, Node.js, Go, Java, C#), and design or review a
+  data model, whether from requirements or against a schema that already
+  exists. Covers namespaces, sets, bins, primary key design, TTL and NSUP,
+  collection data types, expressions, secondary indexes, batch and scan
+  workflows, client policies, connection pooling, record sizing, and schema
+  deliverables. Use when the user sets up Aerospike, writes or debugs Aerospike
+  client code, chooses keys or models data for it, reviews an Aerospike schema
+  before building, or evaluates it as a persistent replacement for Redis or
+  Memcached in real-time, low-latency, feature-store, or user-profile workloads.
+  Core database only: not Aerospike Graph, and not cluster operations, sizing,
+  XDR, or backup and restore, which belong to Aerospike Operations documentation.
+license: Apache-2.0
+metadata:
+  last_verified: "2026-04-21"
+  server_versions: "7.0+"
+---
+
+_Auto-generated from `skills/aerospike-getting-started`, `skills/aerospike-development`, `skills/aerospike-data-modeling` in https://github.com/aerospike/agent-skills. Rule files cited below by bare filename live under `skills/<skill>/` or its `references/` folder in that repository. Edit the skills under `skills/`, not this file._
 
 # Aerospike agent rules
 
@@ -231,7 +253,7 @@ _Auto-generated from `skills/aerospike-getting-started`, `skills/aerospike-devel
 
 
 ### Fetch the data modeling guide before designing a full model [HIGH]
-- This skill carries the decision layer. The full design-time process lives in the
+- This skill carries the decision layer. The full design-time process lives in the https://github.com/aerospike/data-modeling-guide repository. For a new application or a redesign, fetch it and follow its checklist — do not produce a complete model from this skill alone.
 - Prefer: Reading current values (version minimums, size limits, complexity) from the guide rather than recalling them; Naming the specific guide file you used, so a reviewer can retrace the decision
 - Avoid: Presenting a model as complete when the guide's checklist and sizing worksheets were never applied; Quoting a version gate or size limit from memory
 

--- a/compiled-skills/manifest.json
+++ b/compiled-skills/manifest.json
@@ -7,6 +7,6 @@
     "skills/aerospike-data-modeling"
   ],
   "files": {
-    "compiled-skills/SKILLS.md": 43349
+    "compiled-skills/aerospike/SKILL.md": 44831
   }
 }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,134 @@
+# Publishing to agent-skill registries
+
+Registry submission is automated. [`.github/workflows/publish-registries.yml`](../.github/workflows/publish-registries.yml) is the **only** thing in this repository that contacts a registry, so the first listing and every later refresh run the same reviewed code. Nobody should submit by hand.
+
+This document is for whoever cuts a release, or turns publishing on for the first time.
+
+## How to publish
+
+Cut a GitHub release. That is the whole procedure — then approve the environment prompt when GitHub asks.
+
+To rehearse without submitting anything, run the workflow manually from the Actions tab with **Run workflow**. The `dry_run` input defaults to `true`, which renders the exact payloads into the job summary and contacts nothing.
+
+## The four gates
+
+Every gate must pass before a single request leaves the runner.
+
+```mermaid
+flowchart TD
+    Rel[release published] --> Conf[1: conformance workflows]
+    Conf --> Vis[2: repository is public]
+    Vis --> Flag[3: REGISTRY_PUBLISH_ENABLED is true]
+    Flag --> Env[4: registries environment approval]
+    Env --> Submit[submit to openagentskill + upskill]
+    Conf -->|fail| Fail[workflow fails, nothing submitted]
+    Vis -->|not public| Skip[skipped with a notice]
+    Flag -->|not true| Skip
+```
+
+| Gate | Mechanism | Why |
+|------|-----------|-----|
+| 1. Conformance | `needs:` on [`spec-conformance.yml`](../.github/workflows/spec-conformance.yml), [`skill-validator.yml`](../.github/workflows/skill-validator.yml), and [`compile-agents.yml`](../.github/workflows/compile-agents.yml) | Never publish a tree that fails the standard, or an artifact that lags the sources it was compiled from. The pull request run does not prove the tag is clean. |
+| 2. Visibility | `gh api repos/... --jq .visibility` must be `public` | Every registry validates a public URL. Submitting a link that 404s wastes our one credible shot with that registry. |
+| 3. Kill switch | Repository variable `REGISTRY_PUBLISH_ENABLED` must be exactly `true` | The deliberate hold, and the rollback. Setting it back to `false` stops all publishing without reverting code. |
+| 4. Approval | The publish job runs in the `registries` environment | Neither registry documents a way to delete a submission, so a human confirms every one. **Permanent, not just for the initial rollout.** |
+
+Gates 2 and 3 **skip with a notice** instead of failing, so a release cut while publishing is held does not produce a red build. Gate 1 fails hard.
+
+## Turning publishing on for the first time
+
+Prerequisites: the repository is public, and open-source sign-off is recorded on [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
+
+1. Run the workflow manually with `dry_run: true` and confirm the rendered payloads look right. Do this after the repository is public — openagentskill's `/validate` endpoint reads `SKILL.md` over the public URL, so it is the first check that can only pass once we are public.
+2. Create the `registries` environment (**Settings → Environments**) and add the [code owners](../.github/CODEOWNERS) as **required reviewers**. Without reviewers configured, gate 4 does nothing.
+3. Set the repository variable (**Settings → Variables → Actions**): `REGISTRY_PUBLISH_ENABLED` = `true`.
+4. Cut a release, or run the workflow with `dry_run: false`.
+5. Approve the pending environment prompt.
+6. Verify each listing URL resolves and record it in the table below.
+
+## Registries
+
+### openagentskill.com — primary
+
+- **Listing:** https://www.openagentskill.com
+- **Mechanism:** public `POST /api/skills/submit`. No account, free, and zero-star repositories are explicitly accepted.
+- **Script:** [`scripts/publish-openagentskill.sh`](../scripts/publish-openagentskill.sh)
+
+The script resolves the repository through `POST /api/skills/validate` first, then submits one payload for the compiled skill:
+
+```json
+{
+  "repository": "https://github.com/aerospike/agent-skills",
+  "skillPath": "compiled-skills/aerospike/SKILL.md",
+  "submissionSource": "agent",
+  "submittedByAgent": "aerospike-agent-skills-ci"
+}
+```
+
+Two behaviors worth knowing:
+
+- **Re-submission is expected and safe.** A duplicate response is treated as success, which is what makes a release-triggered refresh idempotent.
+- **Listed and recommended are different states.** Only Reviewed, Verified, or Agent Proven skills enter default agent recommendations. Appearing in the directory does not mean agents will suggest us.
+
+Each submission returns `{id, token, statusUrl}`. **The token is the only way to poll that submission later.** Tokens are private, so the workflow keeps them out of logs and the job summary, uploading them as the `registry-receipts` artifact (90-day retention). Transcribe them into the table below before the artifact expires.
+
+### upskill (Autoloops) — secondary
+
+- **Listing:** https://upskill.autoloops.ai/
+- **Mechanism:** CLI publish with `@autoloops/upskill`, pinned in the workflow.
+- **Script:** [`scripts/publish-upskill.sh`](../scripts/publish-upskill.sh)
+
+The trap here is worth stating plainly: submissions are **disabled by default**, and `upskill submit` exits **successfully while doing nothing** when they are off. A naive workflow reports a green publish that never happened. The script therefore sets `submissions true` and then verifies the setting landed in `~/.config/upskill/config.json`, failing if it did not and warning loudly if the config file cannot be found.
+
+Skills land in the `community` trust tier. Promotion to `reviewed` or `verified` is on upskill's roadmap and has no documented criteria or SLA, so do not promise a timeline.
+
+Submitted URLs point at the **default branch**, not the release tag, so a listing keeps tracking updates rather than freezing at one release.
+
+### skills.sh — best-effort, nothing to automate
+
+- **Listing:** https://skills.sh (operated by Vercel)
+- **Mechanism:** **none.** There is no form, no API, and no index repository to open a pull request against.
+
+skills.sh indexes only what arrives through anonymous install telemetry from the `skills` CLI. Widely-circulated advice to open a pull request against `vercel-labs/skills` is wrong; the issue asking exactly that ([#880](https://github.com/vercel-labs/skills/issues/880)) is open and unanswered, and a pull request documenting that listing is telemetry-driven ([#1482](https://github.com/vercel-labs/skills/pull/1482)) is unmerged.
+
+What we can do, and have done:
+
+- Publish `npx skills add https://github.com/aerospike/agent-skills/tree/main/compiled-skills/aerospike` in [`README.md`](../README.md) and [`compiled-skills/README.md`](../compiled-skills/README.md), because real installs are the only input to their index. The CLI discovers `skills/` first and would otherwise install the three authoring folders rather than the compiled skill.
+- Ship [`skills.sh.json`](../skills.sh.json) so the repository page presents our published skill sensibly once it appears. This is display-only and does not affect whether we are listed.
+
+Note the known gap where install telemetry registers but the detail page still 404s ([#1610](https://github.com/vercel-labs/skills/issues/1610)). This is why skills.sh cannot be one of the committed listings for [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
+
+### Not a registry: agentskills.io
+
+`agentskills.io` hosts the **specification**, not a directory. Its [CONTRIBUTING.md](https://github.com/agentskills/agentskills/blob/main/CONTRIBUTING.md) says: "Skill submissions — We don't maintain a directory of community skills. This may change in the future." `/submit`, `/registry`, and `/skills` all 404. We conform to its spec (see below) but cannot list there.
+
+## Adding another registry
+
+1. Add a `scripts/publish-<registry>.sh` that supports `--dry-run` and appends JSON receipts, matching the two existing scripts.
+2. Add a step to the `publish` job in [`publish-registries.yml`](../.github/workflows/publish-registries.yml), and a rendering line to the `dry-run` job.
+3. Document the mechanism and any traps in this file.
+
+Keeping submission logic in scripts rather than inline YAML is deliberate: a maintainer can dry-run it locally without pushing a branch.
+
+## Spec conformance
+
+Registries validate against the [Agent Skills specification](https://agentskills.io/specification), so conformance is a publishing prerequisite, not a formality.
+
+```bash
+./scripts/validate-spec.sh   # official skills-ref validator, spec conformance only
+./scripts/validate-skill.sh  # third-party linter: links, token counts, layout
+```
+
+Both run in CI on every pull request that touches `skills/`. Both also cover `compiled-skills/aerospike/`, the artifact registries actually fetch. The spec allows only six frontmatter keys — `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` — and anything else, including our `last_verified`, belongs under `metadata`. See [CONTRIBUTING.md](../CONTRIBUTING.md#skill-frontmatter-skillmd).
+
+`skills-ref` has no PyPI release and describes itself as a demonstration library, so it is installed from a pinned commit recorded in both [`scripts/validate-spec.sh`](../scripts/validate-spec.sh) and [`spec-conformance.yml`](../.github/workflows/spec-conformance.yml). Keep the two in sync.
+
+## Live listings
+
+Fill in as submissions land, and record the same links on [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
+
+| Registry | Listing URL | Submission id | First submitted | Notes |
+|----------|-------------|---------------|-----------------|-------|
+| openagentskill | _pending_ | _pending_ | _pending_ | Tokens in the `registry-receipts` artifact |
+| upskill | _pending_ | n/a | _pending_ | `community` trust tier |
+| skills.sh | _pending_ | n/a | n/a | Telemetry-driven; no submission |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Tests import the compiler as `scripts.skills_compile.*`, matching how
+# scripts/compile-agents.py imports it, so the repository root must be importable.
+pythonpath = .
+testpaths = tests/unit

--- a/scripts/compile-agents.py
+++ b/scripts/compile-agents.py
@@ -2,7 +2,9 @@
 """Compile the skills/ source-of-truth into compiled-skills/ consumption artifacts.
 
 The modular files under ``skills/`` are the source of truth for authors; this
-script builds the published ``compiled-skills/SKILLS.md`` that end users download.
+script builds the published ``compiled-skills/aerospike/SKILL.md`` that registries
+fetch and end users download. Its frontmatter is hand-written in
+``scripts/skills_compile/published_skill.yaml``.
 
 Usage (maintainers):
     python scripts/compile-agents.py --write
@@ -16,9 +18,24 @@ import json
 import pathlib
 import sys
 
+import yaml
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 COMPILED_DIR = "compiled-skills"
-SINGLE_OUT = f"{COMPILED_DIR}/SKILLS.md"
+PUBLISHED_NAME = "aerospike"
+# Folder name must equal the frontmatter `name`: the spec convention, and what the
+# skills CLI uses as the install directory.
+SINGLE_OUT = f"{COMPILED_DIR}/{PUBLISHED_NAME}/SKILL.md"
+LEGACY_SINGLE_OUT = f"{COMPILED_DIR}/SKILLS.md"
+REPO_URL = "https://github.com/aerospike/agent-skills"
+SPEC_KEYS = {
+    "name",
+    "description",
+    "license",
+    "compatibility",
+    "metadata",
+    "allowed-tools",
+}
 
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -37,9 +54,39 @@ RENDERERS = {
 }
 
 
+def _frontmatter() -> str:
+    """Return the published skill's YAML frontmatter block.
+
+    Emitted verbatim rather than re-serialized, so the author controls formatting
+    and ``--check`` stays byte-stable across runs. Validated here so a malformed
+    header fails the compile instead of a registry submission.
+    """
+    src = REPO_ROOT / "scripts" / "skills_compile" / "published_skill.yaml"
+    text = src.read_text(encoding="utf-8").strip("\n")
+    meta = yaml.safe_load(text) or {}
+
+    missing = {"name", "description", "license"} - set(meta)
+    if missing:
+        raise ValueError(f"{src.name} is missing required key(s): {sorted(missing)}")
+    extra = set(meta) - SPEC_KEYS
+    if extra:
+        raise ValueError(
+            f"{src.name} has non-spec key(s): {sorted(extra)}. "
+            f"The spec allows only {sorted(SPEC_KEYS)}."
+        )
+    if meta["name"] != PUBLISHED_NAME:
+        raise ValueError(
+            f"{src.name} declares name {meta['name']!r} but the published folder is "
+            f"{PUBLISHED_NAME!r}; they must match."
+        )
+    return f"---\n{text}\n---\n"
+
+
 def _header(skill_dirs: list[str]) -> str:
     return (
-        f"_Auto-generated from `{'`, `'.join(skill_dirs)}`. "
+        f"_Auto-generated from `{'`, `'.join(skill_dirs)}` in {REPO_URL}. "
+        f"Rule files cited below by bare filename live under "
+        f"`skills/<skill>/` or its `references/` folder in that repository. "
         f"Edit the skills under `skills/`, not this file._\n"
     )
 
@@ -56,7 +103,7 @@ def compile_outputs(
 
     if layout == "single":
         body = render(skills).strip()
-        out[SINGLE_OUT] = f"{_header(skill_dirs)}\n{body}\n"
+        out[SINGLE_OUT] = f"{_frontmatter()}\n{_header(skill_dirs)}\n{body}\n"
         return out
 
     if layout == "multi":
@@ -86,7 +133,7 @@ def main(argv: list[str] | None = None) -> int:
         "--layout",
         choices=["single", "multi"],
         default="single",
-        help="single -> compiled-skills/SKILLS.md; multi -> one .md per skill",
+        help="single -> compiled-skills/aerospike/SKILL.md; multi -> one .md per skill",
     )
     ap.add_argument("--skills", nargs="*", default=DEFAULT_SKILLS)
     ap.add_argument("--write", action="store_true")
@@ -103,6 +150,8 @@ def main(argv: list[str] | None = None) -> int:
             path = REPO_ROOT / rel
             if not path.exists() or path.read_text(encoding="utf-8") != expected:
                 stale.append(rel)
+        if (REPO_ROOT / LEGACY_SINGLE_OUT).exists():
+            stale.append(f"{LEGACY_SINGLE_OUT} (superseded by {SINGLE_OUT}; delete it)")
         manifest_path = out_root / "manifest.json"
         if manifest_path.exists():
             try:

--- a/scripts/publish-openagentskill.sh
+++ b/scripts/publish-openagentskill.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Submit the compiled skill (compiled-skills/aerospike) to openagentskill.com.
+#
+# Called by .github/workflows/publish-registries.yml, and runnable by hand for
+# debugging. Submission is idempotent: a duplicate response counts as success, so
+# re-running on a later release refreshes rather than errors.
+#
+# Docs: https://www.openagentskill.com/submit
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API="${OAS_API:-https://openagentskill.com/api}"
+REPO_URL=""
+AGENT_ID="aerospike-agent-skills-ci"
+RECEIPTS=""
+DRY_RUN=0
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: publish-openagentskill.sh --repo-url URL [options]
+
+  --repo-url URL     Public GitHub URL of this repository (required).
+  --agent-id ID      Value for submittedByAgent. Default: aerospike-agent-skills-ci
+  --receipts FILE    Append one JSON receipt per skill to FILE.
+  --dry-run          Render and check payloads; make no network calls.
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-url) REPO_URL="${2:?--repo-url needs a value}"; shift 2 ;;
+    --agent-id) AGENT_ID="${2:?--agent-id needs a value}"; shift 2 ;;
+    --receipts) RECEIPTS="${2:?--receipts needs a value}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+[[ -n "${REPO_URL}" ]] || { echo "--repo-url is required." >&2; usage; }
+for tool in curl jq; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "${tool} is required." >&2; exit 3; }
+done
+
+# One published artifact, compiled from the three skills under skills/. The
+# authoring folders are the source of truth, not what registries list.
+SKILL_NAME="aerospike"
+SKILL_PATH="compiled-skills/${SKILL_NAME}/SKILL.md"
+[[ -f "${ROOT}/${SKILL_PATH}" ]] || {
+  echo "${SKILL_PATH} not found. Run: python3 scripts/compile-agents.py --write" >&2
+  exit 1
+}
+
+# The /validate endpoint fetches SKILL.md over the public URL, so it cannot succeed
+# while the repository is private or internal. Skipped in dry-run for that reason:
+# calling it before the repo is public reports a failure that looks like our bug.
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  echo "Resolving skill paths via ${API}/skills/validate"
+  validate_body="$(jq -cn --arg repository "${REPO_URL}" '{repository: $repository}')"
+  validate_out="$(curl -sS -X POST "${API}/skills/validate" \
+    -H 'Content-Type: application/json' \
+    -d "${validate_body}" \
+    -w '\n%{http_code}')"
+  validate_code="$(tail -n1 <<<"${validate_out}")"
+  if [[ "${validate_code}" != 2* ]]; then
+    echo "Registry could not read ${REPO_URL} (HTTP ${validate_code})." >&2
+    echo "This usually means the repository is not publicly readable yet." >&2
+    sed '$d' <<<"${validate_out}" >&2
+    exit 1
+  fi
+fi
+
+failures=0
+for name in "${SKILL_NAME}"; do
+  skill_path="${SKILL_PATH}"
+
+  payload="$(jq -cn \
+    --arg repository "${REPO_URL}" \
+    --arg skillPath "${skill_path}" \
+    --arg agent "${AGENT_ID}" \
+    '{repository: $repository, skillPath: $skillPath, submissionSource: "agent", submittedByAgent: $agent}')"
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    # Assert the payload carries what the API documents as required, so a dry run
+    # catches a malformed request instead of deferring it to the real submission.
+    if ! jq -e '(.repository | length > 0) and (.skillPath | length > 0)' >/dev/null <<<"${payload}"; then
+      echo "DRY RUN: payload for ${name} is missing required fields." >&2
+      failures=$((failures + 1))
+      continue
+    fi
+    echo "DRY RUN ${name}: POST ${API}/skills/submit"
+    jq . <<<"${payload}"
+    continue
+  fi
+
+  echo "Submitting ${name}"
+  response="$(curl -sS -X POST "${API}/skills/submit" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}" \
+    -w '\n%{http_code}')"
+  code="$(tail -n1 <<<"${response}")"
+  body="$(sed '$d' <<<"${response}")"
+
+  status="submitted"
+  if [[ "${code}" != 2* ]]; then
+    # Re-submitting an existing skill is the expected steady state on every release
+    # after the first, so treat it as success rather than failing the workflow.
+    if grep -qiE 'already|duplicate|exists' <<<"${body}"; then
+      status="already-listed"
+      echo "  ${name}: already listed, nothing to do."
+    else
+      echo "  ${name}: submission failed (HTTP ${code})." >&2
+      echo "  ${body}" >&2
+      failures=$((failures + 1))
+      continue
+    fi
+  fi
+
+  if [[ -n "${RECEIPTS}" ]]; then
+    jq -cn \
+      --arg registry "openagentskill" \
+      --arg skill "${name}" \
+      --arg status "${status}" \
+      --argjson response "$(jq -c '.' <<<"${body}" 2>/dev/null || echo '{}')" \
+      '{registry: $registry, skill: $skill, status: $status, response: $response}' \
+      >>"${RECEIPTS}"
+  fi
+
+  # The status token is the only way to poll this submission later, but it is
+  # private -- keep it out of logs and let the caller archive the receipts file.
+  jq -r '"  " + (.submission.status // "submitted") + " id=" + (.submission.id // "unknown")' \
+    <<<"${body}" 2>/dev/null || true
+done
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "openagentskill: ${failures} skill(s) failed." >&2
+  exit 1
+fi
+
+echo "openagentskill: done ($([[ "${DRY_RUN}" -eq 1 ]] && echo "dry run" || echo "submitted"))."

--- a/scripts/publish-upskill.sh
+++ b/scripts/publish-upskill.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Submit the compiled skill (compiled-skills/aerospike) to upskill (Autoloops).
+#
+# Called by .github/workflows/publish-registries.yml, and runnable by hand for
+# debugging.
+#
+# Docs: https://github.com/Autoloops/upskill
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_URL=""
+REF="main"
+RECEIPTS=""
+DRY_RUN=0
+CONFIG_PATH="${UPSKILL_CONFIG:-${HOME}/.config/upskill/config.json}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: publish-upskill.sh --repo-url URL [options]
+
+  --repo-url URL     Public GitHub URL of this repository (required).
+  --ref REF          Branch or tag the submitted tree URLs point at. Default: main
+  --receipts FILE    Append one JSON receipt per skill to FILE.
+  --dry-run          Render the submissions; make no network calls.
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-url) REPO_URL="${2:?--repo-url needs a value}"; shift 2 ;;
+    --ref) REF="${2:?--ref needs a value}"; shift 2 ;;
+    --receipts) RECEIPTS="${2:?--receipts needs a value}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+[[ -n "${REPO_URL}" ]] || { echo "--repo-url is required." >&2; usage; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required." >&2; exit 3; }
+
+# One published artifact, compiled from the three skills under skills/.
+SKILL_NAME="aerospike"
+SKILL_DIR_REL="compiled-skills/${SKILL_NAME}"
+[[ -f "${ROOT}/${SKILL_DIR_REL}/SKILL.md" ]] || {
+  echo "${SKILL_DIR_REL}/SKILL.md not found. Run: python3 scripts/compile-agents.py --write" >&2
+  exit 1
+}
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  command -v upskill >/dev/null 2>&1 || {
+    echo "upskill not found on PATH. Install with: npm install -g @autoloops/upskill" >&2
+    exit 3
+  }
+
+  upskill install
+  # Submissions are disabled by default, and `upskill submit` exits 0 while doing
+  # nothing when they are off. Without this the workflow reports a successful
+  # publish that never happened, so verify the setting actually took effect.
+  upskill config set submissions true
+
+  if [[ -f "${CONFIG_PATH}" ]]; then
+    if ! jq -e '.submissions == true' >/dev/null "${CONFIG_PATH}"; then
+      echo "upskill submissions are still disabled in ${CONFIG_PATH}; refusing to" >&2
+      echo "continue, because submit would silently no-op." >&2
+      exit 1
+    fi
+    echo "Verified submissions are enabled in ${CONFIG_PATH}."
+  else
+    echo "::warning::Could not find ${CONFIG_PATH} to confirm submissions are enabled."
+    echo "::warning::Treat this run's upskill results as unconfirmed and check the listing by hand."
+  fi
+fi
+
+failures=0
+for name in "${SKILL_NAME}"; do
+  # Submit a branch URL rather than the release tag so the listing tracks later
+  # updates instead of pinning to one release.
+  target="${REPO_URL}/tree/${REF}/${SKILL_DIR_REL}"
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "DRY RUN ${name}: upskill submit ${target}"
+    continue
+  fi
+
+  echo "Submitting ${name}"
+  status="submitted"
+  if ! upskill submit "${target}"; then
+    echo "  ${name}: upskill submit failed." >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if [[ -n "${RECEIPTS}" ]]; then
+    jq -cn \
+      --arg registry "upskill" \
+      --arg skill "${name}" \
+      --arg status "${status}" \
+      --arg target "${target}" \
+      '{registry: $registry, skill: $skill, status: $status, target: $target}' \
+      >>"${RECEIPTS}"
+  fi
+done
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "upskill: ${failures} skill(s) failed." >&2
+  exit 1
+fi
+
+echo "upskill: done ($([[ "${DRY_RUN}" -eq 1 ]] && echo "dry run" || echo "submitted"))."

--- a/scripts/requirements-test.txt
+++ b/scripts/requirements-test.txt
@@ -1,0 +1,2 @@
+# Pins the pytest version CI runs.
+pytest==7.4.0

--- a/scripts/skills_compile/published_skill.yaml
+++ b/scripts/skills_compile/published_skill.yaml
@@ -1,0 +1,19 @@
+name: aerospike
+description: >-
+  Work with the Aerospike core database end to end: run a local instance with
+  Docker and verify a first write and read, build or review client code with the
+  official SDKs (Python, Node.js, Go, Java, C#), and design or review a
+  data model, whether from requirements or against a schema that already
+  exists. Covers namespaces, sets, bins, primary key design, TTL and NSUP,
+  collection data types, expressions, secondary indexes, batch and scan
+  workflows, client policies, connection pooling, record sizing, and schema
+  deliverables. Use when the user sets up Aerospike, writes or debugs Aerospike
+  client code, chooses keys or models data for it, reviews an Aerospike schema
+  before building, or evaluates it as a persistent replacement for Redis or
+  Memcached in real-time, low-latency, feature-store, or user-profile workloads.
+  Core database only: not Aerospike Graph, and not cluster operations, sizing,
+  XDR, or backup and restore, which belong to Aerospike Operations documentation.
+license: Apache-2.0
+metadata:
+  last_verified: "2026-04-21"
+  server_versions: "7.0+"

--- a/scripts/skills_compile/skillsrc.py
+++ b/scripts/skills_compile/skillsrc.py
@@ -17,7 +17,14 @@ from typing import Any
 import yaml
 
 _FM_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
-_LABEL_RE = re.compile(r"^\*\*(.+?)\*\*\s*$", re.MULTILINE)
+# The five labels references/_template.md defines. Matching a closed set keeps
+# bold *content* lines -- an enumerated heading, a bolded URL -- from being read
+# as section boundaries, which silently truncates the rule they sit inside.
+CANONICAL_LABELS = ("Rule", "Why", "Prefer", "Avoid", "See also")
+_LABEL_RE = re.compile(
+    r"^\*\*(" + "|".join(re.escape(label) for label in CANONICAL_LABELS) + r")\*\*\s*$",
+    re.MULTILINE,
+)
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$", re.MULTILINE)
 
 # Reference-folder files that are scaffolding rather than knowledge.

--- a/scripts/validate-skill.sh
+++ b/scripts/validate-skill.sh
@@ -4,13 +4,15 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# Multi-skill root: skill-validator discovers each subdirectory that contains SKILL.md.
-SKILL_DIR="${ROOT}/skills"
+# Multi-skill roots: skill-validator discovers each subdirectory containing SKILL.md.
+# compiled-skills/ holds the published artifact, which must be linted like the sources.
+SKILL_ROOTS=("${ROOT}/skills" "${ROOT}/compiled-skills")
 
 usage() {
-  echo "Usage: $0 [--ci]" >&2
-  echo "  --ci   GitHub Actions: --emit-annotations and no --strict (warnings exit 2)." >&2
-  echo "        Default local run uses --strict so warnings fail the script." >&2
+  echo "Usage: $0 [--ci | --summary]" >&2
+  echo "  --ci        GitHub Actions: --emit-annotations and no --strict (warnings exit 2)." >&2
+  echo "  --summary   Markdown report for a job summary: no --strict, no annotations." >&2
+  echo "              Default local run uses --strict so warnings fail the script." >&2
   exit 2
 }
 
@@ -20,6 +22,11 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --ci)
       extra_args+=(--emit-annotations)
+      strict_flag=()
+      ;;
+    --summary)
+      # No annotations: they would be interleaved into the markdown report.
+      extra_args+=(-o markdown)
       strict_flag=()
       ;;
     -h|--help) usage ;;
@@ -35,8 +42,37 @@ if ! command -v skill-validator >/dev/null 2>&1; then
   exit 3
 fi
 
-exec skill-validator check \
-  "${strict_flag[@]}" \
-  --allow-flat-layouts --allow-extra-frontmatter \
-  "${extra_args[@]}" \
-  "${SKILL_DIR}/"
+# No --allow-extra-frontmatter: the Agent Skills spec allows only six frontmatter
+# keys, so an unexpected key must surface here rather than being waived.
+# Run per root and surface the worst exit code, so one clean root cannot mask a
+# failure in the other. Exit 2 means warnings-only when --strict is off.
+worst=0
+for root in "${SKILL_ROOTS[@]}"; do
+  skip_args=()
+  # Skip only the links group for compiled-skills/. The compiled body's links
+  # are inherited from skills/, which this loop still link-checks in full, and
+  # two of the URLs (github.com/aerospike/agent-skills and
+  # github.com/aerospike/data-modeling-guide) cannot resolve until those
+  # repositories are public. A blanket --skip links on both roots would hide
+  # real authoring bugs in skills/.
+  if [[ "${root}" == "${ROOT}/compiled-skills" ]]; then
+    skip_args+=(--skip links)
+  fi
+  set +e
+  skill-validator check \
+    "${strict_flag[@]}" \
+    --allow-flat-layouts \
+    "${skip_args[@]}" \
+    "${extra_args[@]}" \
+    "${root}/"
+  code=$?
+  set -e
+  # skill-validator exits 1 for errors and 2 for warnings-only, so 1 outranks 2.
+  # A numeric max would let warnings in one root mask errors in another.
+  if [[ "${code}" -eq 1 || "${worst}" -eq 1 ]]; then
+    worst=1
+  elif [[ "${code}" -ne 0 ]]; then
+    worst="${code}"
+  fi
+done
+exit "${worst}"

--- a/scripts/validate-spec.sh
+++ b/scripts/validate-spec.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Check every skill under skills/ against the Agent Skills specification using the
+# official reference validator (agentskills/agentskills, skills-ref).
+#
+# This is deliberately separate from scripts/validate-skill.sh: that script runs a
+# third-party linter whose checks are a superset of the spec (links, token counts,
+# file layout). This one answers only "does the frontmatter conform to the standard",
+# which is what registries validate against.
+#
+# Keep SKILLS_REF_REF in sync with .github/workflows/spec-conformance.yml.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILLS_DIR="${ROOT}/skills"
+# The compiled skill is what registries fetch and validate, so it must conform too.
+PUBLISHED_DIR="${ROOT}/compiled-skills/aerospike"
+SKILLS_REF_REF="69ef37e9424c0a7ea9dd2293b559e43ec8176379"
+
+if ! command -v skills-ref >/dev/null 2>&1; then
+  cat >&2 <<EOF
+skills-ref not found on PATH. It has no PyPI release, so install it from source
+(requires Python 3.11+):
+
+  python3 -m venv .venv && . .venv/bin/activate
+  pip install "git+https://github.com/agentskills/agentskills.git@${SKILLS_REF_REF}#subdirectory=skills-ref"
+
+EOF
+  exit 3
+fi
+
+# skills-ref validates one directory per invocation, so loop and aggregate rather
+# than exiting on the first failure -- one run should report every problem.
+skill_dirs=()
+for skill_dir in "${SKILLS_DIR}"/*/; do
+  [[ -f "${skill_dir}SKILL.md" ]] && skill_dirs+=("${skill_dir%/}")
+done
+[[ -f "${PUBLISHED_DIR}/SKILL.md" ]] && skill_dirs+=("${PUBLISHED_DIR}")
+
+failed=()
+checked=0
+for skill_dir in "${skill_dirs[@]}"; do
+  checked=$((checked + 1))
+  if ! skills-ref validate "${skill_dir}"; then
+    failed+=("$(basename "${skill_dir}")")
+  fi
+done
+
+if [[ "${checked}" -eq 0 ]]; then
+  echo "No skills found under ${SKILLS_DIR}/ -- expected at least one SKILL.md." >&2
+  exit 1
+fi
+
+if [[ "${#failed[@]}" -gt 0 ]]; then
+  echo >&2
+  echo "Spec conformance failed for ${#failed[@]} of ${checked} skill(s): ${failed[*]}" >&2
+  echo "The spec allows only these frontmatter keys: name, description, license," >&2
+  echo "compatibility, metadata, allowed-tools. Put anything else under metadata." >&2
+  echo "See https://agentskills.io/specification" >&2
+  exit 1
+fi
+
+echo "All ${checked} skill(s) conform to the Agent Skills specification."

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Aerospike",
+      "description": "Agent skill for the Aerospike core database: local setup, application development, and design-time data modeling. Core database only, not Aerospike Graph.",
+      "skills": [
+        "aerospike"
+      ]
+    }
+  ]
+}

--- a/skills/aerospike-data-modeling/SKILL.md
+++ b/skills/aerospike-data-modeling/SKILL.md
@@ -9,7 +9,10 @@ description: >-
   reviewing client code against a model that already exists, or for client APIs,
   policies, CDT operations, and expression usage, use aerospike-development
   instead. Core database only; not Aerospike Graph.
-last_verified: 2026-08-06
+license: Apache-2.0
+metadata:
+  last_verified: "2026-08-06"
+  server_versions: "7.0+"
 ---
 
 # Aerospike: data model design

--- a/skills/aerospike-development/SKILL.md
+++ b/skills/aerospike-development/SKILL.md
@@ -9,7 +9,10 @@ description: >-
   aerospike-data-modeling instead. Redirect cluster deployment sizing
   XDR and backup questions to Aerospike Operations documentation. Core
   database only; not Aerospike Graph.
-last_verified: 2026-04-21
+license: Apache-2.0
+metadata:
+  last_verified: "2026-04-21"
+  server_versions: "7.0+"
 ---
 
 # Aerospike: application development

--- a/skills/aerospike-development/references/_template.md
+++ b/skills/aerospike-development/references/_template.md
@@ -28,5 +28,5 @@ Short rationale tied to Aerospike behavior or client architecture.
 
 **See also**
 
-- [Related rule](other-rule.md) (if applicable)
+- Related rule, if applicable, written as `[Rule Title]` followed by `(rule-filename.md)`
 - Language hubs: [Java](https://aerospike.com/docs/develop/client/java), [Python](https://aerospike.com/docs/develop/client/python), [Go](https://aerospike.com/docs/develop/client/go), [Node.js](https://aerospike.com/docs/develop/client/node)

--- a/skills/aerospike-development/references/ex-batch-read-by-keys.md
+++ b/skills/aerospike-development/references/ex-batch-read-by-keys.md
@@ -11,9 +11,14 @@ Related rules: [batch-parallel-key-operations.md](batch-parallel-key-operations.
 Use your SDK’s batch API with a **list of keys** built from known identifiers—**each key at most once** per batch; dedupe or coalesce on the client, and use batch **`operate`** when one key needs multiple operations (see [batch-parallel-key-operations.md](batch-parallel-key-operations.md)). Pseudocode:
 
 ```
-keys = [ Key(ns, set, id1), Key(ns, set, id2), ... ]
-records = client.batch_get(policy, keys)
+keys    = [ Key(ns, set, id1), Key(ns, set, id2), ... ]
+records = <your SDK's batch read>(keys)
 ```
+
+Method names and argument order differ by language—Python is `client.batch_read(keys)`
+returning a `BatchRecords`, Java is `client.get(batchPolicy, keys)` returning `Record[]`.
+Take the real signature from [ex-official-batch.md](ex-official-batch.md) rather than this
+sketch.
 
 Handle **per-key errors** in the result structure your client returns (not all languages surface failures the same way).
 

--- a/skills/aerospike-development/references/ex-policy-explicit-defaults.md
+++ b/skills/aerospike-development/references/ex-policy-explicit-defaults.md
@@ -14,7 +14,7 @@ import aerospike
 config = {
     "hosts": [("127.0.0.1", 3000)],
     "policies": {
-        "timeout": 1000,
+        "total_timeout": 1000,
         "write": {
             "socket_timeout": 500,
             "max_retries": 2,

--- a/skills/aerospike-getting-started/SKILL.md
+++ b/skills/aerospike-getting-started/SKILL.md
@@ -9,7 +9,10 @@ description: >-
   Aerospike, replaces Redis or Memcached, builds feature stores or user-profile
   caches, or needs Aerospike client connectivity and correct defaults. Core
   database only (not Aerospike Graph).
-last_verified: 2026-04-21
+license: Apache-2.0
+metadata:
+  last_verified: "2026-04-21"
+  server_versions: "7.0+"
 ---
 
 # Aerospike Database: getting started

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,43 @@
+# Tests
+
+| Path | What it covers | How to run |
+|------|----------------|------------|
+| `unit/` | The compiler, the publish scripts, and documentation references | `python3 -m pytest tests/unit -v` |
+| `unit/test_payload_integrity.py` | That every skill folder is self-contained — no link leaves its own folder, and every relative link resolves | `python3 -m pytest tests/unit/test_payload_integrity.py -v` |
+| `triggers/` | Whether the published description fires on the right prompts | `python3 tests/run_triggers.py` — see [`triggers/README.md`](triggers/README.md) |
+| `content/verify-server-claims.sh` | The getting-started skill's claims against a real server | `./tests/content/verify-server-claims.sh` (needs Docker) |
+| `tasks/` | End-to-end task prompts, read by the evaluation harness through its submodule | `python3 -m pytest tests/unit/test_task_corpus.py -v` for their shape; the prompts themselves run in [`agent-skills-eval`](https://github.com/citrusleaf/agent-skills-eval) |
+
+`verify-server-claims.sh` boots `aerospike/aerospike-server:latest`, the Community image the
+skill tells a new user to run, and removes the container when it exits. Pass `--tag` to check
+the claims against a specific release instead. It binds host ports 3000-3002, so stop any
+Aerospike already holding them first. Not every published tag ships `asinfo` — eight
+simultaneous failures mean the tool is missing from the image, not that eight claims drifted
+at once.
+
+## Before publishing
+
+```bash
+python3 -m pytest tests/unit -v                        # compiler, publishing, docs
+python3 scripts/compile-agents.py --shape stripped --check
+./scripts/validate-spec.sh                             # needs skills-ref
+./scripts/validate-skill.sh                            # needs skill-validator
+./tests/content/verify-server-claims.sh                # needs Docker
+
+# Trigger accuracy. Manual because it needs a model API key, which this project
+# does not put in CI. Exits non-zero below the threshold in triggers/README.md.
+set -a && . ./agent_api_key.env && set +a              # gitignored; holds CURSOR_API_KEY
+python3 tests/run_triggers.py --model composer-2.5 --min-accuracy 0.88
+```
+
+`skills-ref` needs Python 3.11 or newer; create its virtualenv with `python3.11 -m venv .venv`.
+
+### Checks a person has to run
+
+These are not automated, and nothing in CI will notice if they are skipped.
+
+- **A live evaluation run** in [`agent-skills-eval`](https://github.com/citrusleaf/agent-skills-eval). Compare `v0_baseline` (no skill) against `v5_published` (the shipped artifact). Check `n_tasks` against the expected total — a stale submodule pointer silently scores the old corpus. Last measured 2026-08-20 on `composer-2.5` (`fast=false`): published **96.7%** vs baseline **95.1%** overall; data-modeling tasks **99.0%** vs **92.9%**.
+- **The client API signature pass.** Compare the constructor, `put`, `get`, `operate`, and the batch read entry point in each skill's `examples.md` and `references/` against current official SDK documentation. Record the date, the SDK versions, and anything that drifted.
+- **These two URLs resolve** (skill-validator skips link checks on `compiled-skills/`; both 404 until the repositories are public):
+  - `https://github.com/aerospike/agent-skills`
+  - `https://github.com/aerospike/data-modeling-guide`

--- a/tests/content/verify-server-claims.sh
+++ b/tests/content/verify-server-claims.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Verify the getting-started skill's factual claims against a real server.
+#
+# Reading documentation cannot catch guidance that was true two releases ago;
+# booting the server can. Each check names the claim it verifies, so a drifted
+# claim points at the file that makes it.
+#
+# Usage: tests/content/verify-server-claims.sh [--tag TAG]
+set -euo pipefail
+
+IMAGE="aerospike/aerospike-server"
+TAG="latest"
+CONTAINER="aerospike-claim-check-$$"
+SKILL="skills/aerospike-getting-started/SKILL.md"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag) TAG="${2:?--tag needs a value}"; shift 2 ;;
+    -h|--help) sed -n '2,9p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v docker >/dev/null 2>&1 || { echo "docker is required." >&2; exit 3; }
+
+passed=0
+failed=0
+
+check() {
+  # check <claim> <source> <command...>
+  local claim="$1" source="$2"; shift 2
+  if "$@" >/dev/null 2>&1; then
+    echo "  ok    ${claim}  (${source})"
+    passed=$((passed + 1))
+  else
+    echo "  FAIL  ${claim}  (${source})" >&2
+    failed=$((failed + 1))
+  fi
+}
+
+asinfo() { docker exec "${CONTAINER}" asinfo -v "$1"; }
+asinfo_has() { asinfo "$1" | grep -qE "$2"; }
+
+cleanup() { docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "Booting ${IMAGE}:${TAG}"
+docker run -d --name "${CONTAINER}" -p 3000-3002:3000-3002 "${IMAGE}:${TAG}" >/dev/null
+
+for _ in $(seq 1 60); do
+  if docker logs "${CONTAINER}" 2>&1 | grep -q "service ready"; then break; fi
+  sleep 1
+done
+docker logs "${CONTAINER}" 2>&1 | grep -q "service ready" || {
+  echo "Server did not report 'service ready' within 60s." >&2
+  docker logs "${CONTAINER}" 2>&1 | tail -20 >&2
+  exit 1
+}
+
+build="$(asinfo build | tr -d '\r')"
+echo "Server build: ${build}"
+echo
+
+# The image name the skill tells a new user to run.
+check "Community image ${IMAGE} boots and serves" "${SKILL}" \
+  asinfo_has "status" "ok"
+
+# The declared floor is 7.0+; anything older invalidates the documented flow.
+check "Build is 7.0 or newer" "${SKILL} metadata.server_versions" \
+  bash -c "[[ \$(printf '%s\n7.0.0\n' '${build}' | sort -V | head -1) == '7.0.0' ]]"
+
+# "The default namespace is test. NEVER use default, aerospike, or main."
+check "Namespace 'test' exists out of the box" "${SKILL} critical rules" \
+  asinfo_has "namespaces" "(^|;)test(;|$)"
+check "Namespace 'default' does not exist" "${SKILL} critical rules" \
+  bash -c "! docker exec ${CONTAINER} asinfo -v namespaces | grep -qE '(^|;)default(;|\$)'"
+
+# cluster-name is mandatory from 7.0.0, which is why the floor is 7.0.
+check "cluster-name is a service config key" "${SKILL} local config" \
+  asinfo_has "get-config:context=service" "cluster-name="
+
+# Expiry: nsup-period drives expiration, default-ttl sets the record default.
+check "nsup-period governs expiration" "${SKILL} TTL and NSUP" \
+  asinfo_has "get-config:context=namespace;id=test" "nsup-period="
+check "default-ttl is a namespace config key" "${SKILL} TTL and NSUP" \
+  asinfo_has "get-config:context=namespace;id=test" "default-ttl="
+
+# The client port the skill tells users to map.
+check "Client port 3000 is reachable from the host" "${SKILL} ports" \
+  bash -c "exec 3<>/dev/tcp/127.0.0.1/3000"
+
+echo
+echo "${passed} claim(s) verified, ${failed} failed."
+[[ "${failed}" -eq 0 ]]

--- a/tests/run_triggers.py
+++ b/tests/run_triggers.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Measure whether the published skill's description fires when it should.
+
+An agent harness decides whether to load a skill from its description alone,
+before the skill's body is ever read. This runner reproduces exactly that
+decision: it shows a model the skill name, the description, and one user
+message, and records which of two answers comes back. It never loads the skill
+body, so what it measures is the description and nothing else.
+
+Offline mode replays recorded verdicts, so the corpus, parsing, and scoring can
+be exercised with no API key and no network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import pathlib
+import sys
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.skills_compile.skillsrc import split_frontmatter  # noqa: E402
+
+PUBLISHED_SKILL = REPO_ROOT / "compiled-skills" / "aerospike" / "SKILL.md"
+CORPUS_DIR = REPO_ROOT / "tests" / "triggers"
+NO_SKILL = "none"
+UNPARSEABLE = "unparseable"
+DEFAULT_MODEL = "composer-2.5"
+
+
+@dataclasses.dataclass(frozen=True)
+class TriggerCase:
+    id: str
+    prompt: str
+    expect: str
+    domain: str | None = None
+    why: str = ""
+
+
+@dataclasses.dataclass(frozen=True)
+class Metrics:
+    total: int
+    correct: int
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+    failures: tuple[tuple[str, str, str], ...]
+
+    @property
+    def accuracy(self) -> float:
+        return self.correct / self.total if self.total else 0.0
+
+    @property
+    def precision(self) -> float:
+        fired = self.true_positives + self.false_positives
+        return self.true_positives / fired if fired else 0.0
+
+    @property
+    def recall(self) -> float:
+        wanted = self.true_positives + self.false_negatives
+        return self.true_positives / wanted if wanted else 0.0
+
+
+def load_published_skill(path: pathlib.Path = PUBLISHED_SKILL) -> tuple[str, str]:
+    """Return the shipped skill's name and description, whitespace collapsed.
+
+    Read from the compiled artifact rather than a copy, so the corpus always
+    scores the description users actually install.
+    """
+    meta, _body = split_frontmatter(path.read_text(encoding="utf-8"))
+    return meta["name"], " ".join(meta["description"].split())
+
+
+def load_corpus(corpus_dir: pathlib.Path) -> list[TriggerCase]:
+    cases: list[TriggerCase] = []
+    seen: set[str] = set()
+    for path in sorted(corpus_dir.glob("*.yaml")):
+        for entry in yaml.safe_load(path.read_text(encoding="utf-8")) or []:
+            case = TriggerCase(
+                id=entry["id"],
+                prompt=" ".join(entry["prompt"].split()),
+                expect=entry["expect"],
+                domain=entry.get("domain"),
+                why=entry.get("why", ""),
+            )
+            if case.id in seen:
+                raise ValueError(f"duplicate case id: {case.id} in {path.name}")
+            seen.add(case.id)
+            cases.append(case)
+
+    if not cases:
+        raise ValueError(f"no trigger cases found under {corpus_dir}")
+
+    name, _description = load_published_skill()
+    allowed = {name, NO_SKILL}
+    for case in cases:
+        if case.expect not in allowed:
+            raise ValueError(f"{case.id}: expect must be one of {sorted(allowed)}")
+    return cases
+
+
+def build_router_prompt(name: str, description: str, user_prompt: str) -> str:
+    return (
+        "You are the skill router in an AI coding assistant. One skill is "
+        "installed. Using only its description, decide whether to load it for "
+        "the user's message.\n\n"
+        f"Skill name: {name}\n"
+        f"Description: {description}\n\n"
+        f"User message: {user_prompt}\n\n"
+        f"Answer with exactly one word: {name} to load the skill, or {NO_SKILL} "
+        "to answer without it."
+    )
+
+
+def parse_verdict(raw: str, skill_name: str) -> str:
+    """Reduce a reply to one allowed answer.
+
+    Models add punctuation, emphasis, and a sentence of reasoning even when told
+    not to, so match on the words present rather than demanding an exact reply.
+    A reply naming the skill wins over one naming neither.
+    """
+    words = {word.strip(".,:;!?\"'`*_").lower() for word in (raw or "").split()}
+    if skill_name.lower() in words:
+        return skill_name
+    if NO_SKILL in words:
+        return NO_SKILL
+    return UNPARSEABLE
+
+
+def score(
+    cases: list[TriggerCase], verdicts: dict[str, str], skill_name: str
+) -> Metrics:
+    correct = true_positives = false_positives = false_negatives = 0
+    failures: list[tuple[str, str, str]] = []
+
+    for case in cases:
+        got = verdicts.get(case.id, UNPARSEABLE)
+        if got == case.expect:
+            correct += 1
+            if got == skill_name:
+                true_positives += 1
+            continue
+        failures.append((case.id, case.expect, got))
+        if case.expect == NO_SKILL:
+            false_positives += 1
+        else:
+            false_negatives += 1
+
+    return Metrics(
+        total=len(cases),
+        correct=correct,
+        true_positives=true_positives,
+        false_positives=false_positives,
+        false_negatives=false_negatives,
+        failures=tuple(failures),
+    )
+
+
+def _ask_model(prompt: str, model: str) -> str:
+    from cursor_sdk import Agent, AgentOptions, LocalAgentOptions
+
+    api_key = os.environ.get("CURSOR_API_KEY")
+    if not api_key:
+        raise SystemExit(
+            "CURSOR_API_KEY is not set. Set it, or pass --offline to score a "
+            "recorded run."
+        )
+    result = Agent.prompt(
+        prompt,
+        AgentOptions(
+            api_key=api_key,
+            model=model,
+            local=LocalAgentOptions(cwd=str(REPO_ROOT)),
+        ),
+    )
+    return getattr(result, "result", "") or ""
+
+
+def _collect_verdicts(
+    cases: list[TriggerCase], name: str, description: str, model: str
+) -> dict[str, str]:
+    verdicts: dict[str, str] = {}
+    for index, case in enumerate(cases, start=1):
+        raw = _ask_model(build_router_prompt(name, description, case.prompt), model)
+        verdicts[case.id] = parse_verdict(raw, name)
+        print(f"  [{index}/{len(cases)}] {case.id}: {verdicts[case.id]}", flush=True)
+    return verdicts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Score the published skill's description against trigger cases."
+    )
+    parser.add_argument("--corpus", type=pathlib.Path, default=CORPUS_DIR)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--offline",
+        type=pathlib.Path,
+        help="JSON file of {case_id: verdict}; scores without calling a model",
+    )
+    parser.add_argument(
+        "--min-accuracy",
+        type=float,
+        default=0.0,
+        help="exit 1 below this overall accuracy",
+    )
+    parser.add_argument("--json", type=pathlib.Path, help="write the report here")
+    args = parser.parse_args(argv)
+
+    cases = load_corpus(args.corpus)
+    name, description = load_published_skill()
+
+    if args.offline:
+        verdicts = json.loads(args.offline.read_text(encoding="utf-8"))
+    else:
+        print(f"Routing {len(cases)} prompts through {args.model}")
+        verdicts = _collect_verdicts(cases, name, description, args.model)
+
+    metrics = score(cases, verdicts, name)
+
+    print(
+        f"\naccuracy {metrics.accuracy:.3f}  "
+        f"precision {metrics.precision:.3f}  "
+        f"recall {metrics.recall:.3f}  "
+        f"({metrics.correct}/{metrics.total})"
+    )
+    for case_id, expected, got in metrics.failures:
+        print(f"  FAIL {case_id}: expected {expected}, got {got}")
+
+    if args.json:
+        args.json.write_text(
+            json.dumps(
+                {
+                    "model": args.model,
+                    "skill": name,
+                    "total": metrics.total,
+                    "correct": metrics.correct,
+                    "accuracy": metrics.accuracy,
+                    "precision": metrics.precision,
+                    "recall": metrics.recall,
+                    "failures": [list(f) for f in metrics.failures],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    if metrics.accuracy < args.min_accuracy:
+        print(
+            f"\nBelow threshold: {metrics.accuracy:.3f} < {args.min_accuracy:.3f}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tasks/data-modeling.yaml
+++ b/tests/tasks/data-modeling.yaml
@@ -1,0 +1,167 @@
+# End-to-end tasks for aerospike-data-modeling, the skill no evaluation run has
+# ever measured. Schema matches the harness in aerospike/agent-skills-eval,
+# which reads this file through its vendor/agent-skills submodule.
+#
+# Regex fields are case-insensitive and searched against the whole output, so a
+# `forbidden` pattern that matches vocabulary the prompt itself invites fails
+# correct answers for echoing the question. The patterns below therefore fire on
+# endorsement or on relational syntax, not on a shared noun.
+- id: dm-design-time-workflow
+  skill: aerospike-data-modeling
+  category: data-modeling
+  prompt: >-
+    We're starting a new service on Aerospike and have no schema yet. Walk me
+    through how to get from our requirements to a data model.
+  required_all:
+    - "access pattern"
+    - "key (design|schema|format)|primary key"
+  required_any:
+    - "entit(y|ies)"
+    - "cardinality"
+    - "who drives the read|read path|write path"
+  forbidden:
+    - "CREATE TABLE"
+    - "\\b(inner|outer|left|right|natural)\\s+join\\b"
+  rubric:
+    - "Starts from access patterns rather than an entity-relationship diagram"
+    - "Covers record granularity, key design, and bin structure"
+    - "Names the deliverables the process produces"
+  expected_refs:
+    - model-design-time-workflow.md
+  weight: 1.0
+
+- id: dm-guide-escalation
+  skill: aerospike-data-modeling
+  category: data-modeling
+  prompt: >-
+    We need a complete Aerospike data model for a new product, not just advice.
+    What's the authoritative process, and is there something more detailed than
+    this skill?
+  required_all:
+    - "data-modeling-guide"
+  required_any:
+    - "github\\.com/aerospike"
+    - "fetch|clone|repository"
+  forbidden:
+    - "no (additional|further) (guide|resource)"
+  rubric:
+    - "Points at the external data modeling guide repository by name"
+    - "Says a full model should not be produced from this skill alone"
+  expected_refs:
+    - ex-guide-escalation.md
+  weight: 1.0
+
+- id: dm-failure-modes-review
+  skill: aerospike-data-modeling
+  category: data-modeling
+  prompt: >-
+    Review this Aerospike design before we build. One set per domain noun, six
+    secondary indexes for our main queries, a separate bin per tag, and a
+    followers list bin per user with no cap.
+  required_all:
+    - "secondary index|\\bSIs?\\b"
+    - "unbounded|\\bcap(s|ped|ping)?\\b|grow"
+  required_any:
+    - "bin per tag|bins like columns"
+    - "key lookup|primary key"
+  # Sentence-final, so only an unqualified verdict counts. A review that credits
+  # one part of a flawed design ("the set layout looks fine, but ...") is a
+  # correct answer and must not be failed for it.
+  forbidden:
+    - "looks (good|fine|solid)\\s*[.!]"
+    - "no (issues|problems)\\s*[.!]"
+  rubric:
+    - "Flags secondary indexes used as the primary query mechanism"
+    - "Flags the unbounded followers collection"
+    - "Flags a bin count that scales with data rather than schema"
+  expected_refs:
+    - model-failure-modes-checklist.md
+  weight: 1.0
+
+- id: dm-record-granularity
+  skill: aerospike-data-modeling
+  category: data-modeling
+  prompt: >-
+    We have users, and each user has a stream of events. Should events be their
+    own Aerospike set, or live inside the user record?
+  required_all:
+    - "cardinality|how many|growth"
+  required_any:
+    - "access pattern"
+    - "record size"
+    - "unbounded"
+  # Relational syntax only. A correct answer explaining the cost of a separate
+  # set says the application has to join the two itself.
+  forbidden:
+    - "\\b(inner|outer|left|right|natural)\\s+join\\b"
+  rubric:
+    - "Makes the decision follow cardinality and the read path, not the noun list"
+    - "Raises record size or unbounded growth as the deciding constraint"
+  # No expected_refs: granularity, denormalization, and hot keys are argued in the
+  # development skill's references, not the data-modeling skill's four. One skill
+  # ships, so the split does not reach a user, and naming a file across skills
+  # would assert a layout we do not have.
+  weight: 1.0
+
+- id: dm-denormalization
+  skill: aerospike-data-modeling
+  category: data-modeling
+  prompt: >-
+    Rendering one post in our Aerospike feed needs the author's display name. Do
+    I read the user record too, or store the name on the post?
+  required_all:
+    - "denormaliz|duplicat"
+  required_any:
+    - "no joins|there are no joins"
+    - "round trip"
+  forbidden:
+    - "\\b(inner|outer|left|right|natural)\\s+join\\b"
+    - "foreign key"
+  rubric:
+    - "Chooses duplication over a second read, and says why"
+    - "Notes the update cost duplication creates"
+  weight: 1.0
+
+- id: dm-hot-key
+  skill: aerospike-data-modeling
+  category: data-modeling
+  prompt: >-
+    I want one Aerospike record holding a global counter that every request
+    increments. Any problem with that?
+  required_all:
+    - "hot[-\\s]?key|hot[-\\s]?spot"
+  required_any:
+    - "shard|split|partition"
+    - "single (record|key)"
+  # The prompt asks "any problem with that?", so only an unconditional blessing
+  # is a failure. "Fine at low write rates, but ..." is a correct answer.
+  forbidden:
+    - "no (problem|issue)s? with (that|this)"
+    - "perfectly fine"
+  rubric:
+    - "Identifies the single-record hot key"
+    - "Offers sharding the counter across records as the fix"
+  weight: 1.0
+
+- id: dm-deliverables
+  skill: aerospike-data-modeling
+  category: data-modeling
+  prompt: >-
+    When you finish designing an Aerospike data model for us, what documents
+    should we end up with?
+  required_all:
+    - "schema guide"
+    - "schema summary"
+  required_any:
+    - "derived|generated from"
+    - "assumptions log"
+    - "index (list|rationale)"
+  forbidden:
+    - "CREATE TABLE"
+    - "\\bDDL\\b"
+  rubric:
+    - "Names the schema guide and the schema summary as the deliverables"
+    - "Describes what each one is for"
+  expected_refs:
+    - model-deliverables-schema-guide-summary.md
+  weight: 1.0

--- a/tests/triggers/README.md
+++ b/tests/triggers/README.md
@@ -1,0 +1,83 @@
+# Trigger accuracy
+
+One skill is published, so cross-triggering between our own skills is designed out
+rather than measured. What remains is whether a single description fires across all
+three domains and stays quiet outside them.
+
+`../run_triggers.py` shows a model only the published skill's name and description
+plus one user message, which is the same information an agent harness has when it
+decides whether to load a skill. It does not load the skill body.
+
+## Corpus
+
+| File | Cases | Expectation |
+|------|-------|-------------|
+| `positives.yaml` | 12 | Must load the skill — four per authoring domain |
+| `negatives.yaml` | 8 | Must not load it — excluded Aerospike topics and unrelated technology |
+| `near-misses.yaml` | 5 | Must not load it — names Aerospike without needing guidance |
+
+`domain` on each positive records which folder under `skills/` would have served the
+prompt, so cross-triggering can be re-measured if those folders are ever published
+separately.
+
+## Threshold
+
+The bar is **0.88** overall accuracy against `composer-2.5`. It is checked by hand
+before publishing, not in CI — see [Running it](#running-it) for why.
+
+That is the worst measured run minus one case, not a target chosen in advance. The
+margin is deliberate and it is not a softer goal: routing is stochastic, and the runs
+below show one or two cases flipping between identical invocations. A threshold set at
+the measurement would fail on that noise alone, which trains people to ignore it.
+One case is 0.04 across 25 cases. Raise it when a description change earns it.
+
+| Date | Model | Accuracy | Precision | Recall | Failed |
+|------|-------|----------|-----------|--------|--------|
+| 2026-08-19 | composer-2.5 | 0.920 | 1.000 | 0.833 | `pos-dm-key-design`, `pos-dm-schema-review` |
+| 2026-08-19 | composer-2.5 | 0.960 | 1.000 | 0.917 | `pos-dev-policy-timeouts` |
+| 2026-08-19 | composer-2.5 | 0.920 | 1.000 | 0.833 | `pos-dev-cdt-map-update`, `pos-dm-schema-review` |
+
+The first run used the original description. Both of its failures were data-modeling
+positives while nothing over-fired, which said the description under-reached
+design-time modeling rather than reaching too far: it offered to review client *code*
+and to design a model *from requirements*, so reviewing an existing model fell between
+those clauses, and key selection appeared only as a noun in the covered-concepts list.
+
+Runs two and three followed a description that names both. `pos-dm-key-design` and
+`pos-dm-schema-review` went from failing both times to passing three of four, and
+precision stayed at 1.000, so the wider reach cost no over-firing. Read that as
+suggestive rather than settled — it is four case-observations.
+
+What runs two and three mainly establish is the variance. Their failures are different
+cases, and neither is one the description change touched, so they are noise. That is
+what the threshold's margin is sized against.
+
+## Running it
+
+This is a manual pre-publish check rather than a CI gate, because it needs a model API
+key and this project does not put one in CI. Run it whenever you change the description,
+and before publishing:
+
+```bash
+set -a && . ./agent_api_key.env && set +a     # gitignored; holds CURSOR_API_KEY
+python3 tests/run_triggers.py --model composer-2.5 --min-accuracy 0.88 --json /tmp/triggers.json
+```
+
+It exits non-zero below the threshold. Add a row to the table above with what you measured,
+whatever the result — the point of the table is the variance, so a bad run is as much a
+data point as a good one.
+
+Scoring is separated from the model calls, so the corpus, parsing, and scoring logic are
+covered by `tests/unit/test_run_triggers.py` in CI with no key and no network. Only the
+measurement itself is manual. To re-score a run you already have:
+
+```bash
+python3 tests/run_triggers.py --offline recorded-verdicts.json --min-accuracy 0.88
+```
+
+## When a case fails
+
+A failing positive means the description does not reach that domain. A failing negative
+or near-miss means it reaches too far. Either way the fix is the description in
+`scripts/skills_compile/published_skill.yaml`, not the corpus — do not edit a case to
+make the run green.

--- a/tests/triggers/near-misses.yaml
+++ b/tests/triggers/near-misses.yaml
@@ -1,0 +1,40 @@
+# Prompts that name Aerospike, or sit next to it, without needing the skill.
+# These are where a broad description over-fires, so they carry the most signal.
+- id: near-invoice-mentions-aerospike
+  prompt: >-
+    Draft an email to our vendor asking why the Aerospike licence invoice went up
+    forty percent this year.
+  expect: none
+  domain: null
+  why: Names Aerospike, needs no technical guidance.
+
+- id: near-resume-bullet
+  prompt: >-
+    Rewrite this resume bullet to sound stronger: "Used Aerospike and Kafka to
+    build a real-time pipeline."
+  expect: none
+  domain: null
+  why: Copywriting that happens to name the product.
+
+- id: near-generic-latency
+  prompt: >-
+    What does p99 latency actually mean and why is it more useful than an
+    average?
+  expect: none
+  domain: null
+  why: Adjacent vocabulary, no Aerospike content.
+
+- id: near-cassandra-modeling
+  prompt: >-
+    How should I model a time series in Cassandra so partitions stay a reasonable
+    size?
+  expect: none
+  domain: null
+  why: Data modeling for a different database.
+
+- id: near-dockerfile-generic
+  prompt: >-
+    How do I make my Dockerfile build faster by ordering layers better?
+  expect: none
+  domain: null
+  why: Docker without Aerospike.

--- a/tests/triggers/negatives.yaml
+++ b/tests/triggers/negatives.yaml
@@ -1,0 +1,64 @@
+# Prompts the published skill must stay quiet on. The first four are Aerospike
+# topics the skill explicitly excludes; the rest are unrelated technology.
+- id: neg-graph
+  prompt: >-
+    How do I write a Gremlin traversal against Aerospike Graph to find
+    second-degree connections?
+  expect: none
+  domain: null
+  why: Aerospike Graph is excluded by name.
+
+- id: neg-xdr
+  prompt: >-
+    Configure XDR shipping from our Aerospike cluster in us-east to the new
+    cluster in eu-west.
+  expect: none
+  domain: null
+  why: XDR belongs to Aerospike Operations.
+
+- id: neg-cluster-sizing
+  prompt: >-
+    How many nodes and how much RAM do we need for an Aerospike cluster holding
+    twelve billion records?
+  expect: none
+  domain: null
+  why: Cluster sizing belongs to Aerospike Operations.
+
+- id: neg-backup-restore
+  prompt: >-
+    What's the procedure for restoring an Aerospike namespace from an asbackup
+    archive taken last week?
+  expect: none
+  domain: null
+  why: Backup and restore belongs to Aerospike Operations.
+
+- id: neg-postgres-index
+  prompt: >-
+    My Postgres query does a sequential scan on a ten million row table. How do I
+    get it to use the index?
+  expect: none
+  domain: null
+  why: Unrelated database.
+
+- id: neg-react-hooks
+  prompt: >-
+    Why does my React component re-render every time the parent state changes,
+    even though I wrapped it in memo?
+  expect: none
+  domain: null
+  why: Unrelated technology.
+
+- id: neg-k8s-crashloop
+  prompt: >-
+    My pod is in CrashLoopBackOff and the logs are empty. How do I debug it?
+  expect: none
+  domain: null
+  why: Unrelated infrastructure.
+
+- id: neg-git-rebase
+  prompt: >-
+    I rebased onto main and now I have forty conflicts. What's the fastest way
+    out of this?
+  expect: none
+  domain: null
+  why: Unrelated tooling.

--- a/tests/triggers/positives.yaml
+++ b/tests/triggers/positives.yaml
@@ -1,0 +1,99 @@
+# Prompts the published skill must fire on. `domain` records which authoring
+# folder under skills/ would have served the prompt, so cross-triggering can be
+# re-measured if those folders are ever published separately.
+- id: pos-gs-docker-local
+  prompt: >-
+    I'm new to Aerospike. How do I get a single node running locally with Docker
+    and check that it actually started?
+  expect: aerospike
+  domain: aerospike-getting-started
+  why: Local setup is the getting-started core.
+
+- id: pos-gs-default-namespace
+  prompt: >-
+    My Aerospike client keeps failing with a namespace error. What namespace does
+    a fresh install actually have?
+  expect: aerospike
+  domain: aerospike-getting-started
+  why: Namespace defaults are a named anti-hallucination rule.
+
+- id: pos-gs-redis-replacement
+  prompt: >-
+    We're outgrowing Redis for our session store and need something that persists
+    to disk at the same latency. Is Aerospike a fit, and how do I try it?
+  expect: aerospike
+  domain: aerospike-getting-started
+  why: The Redis-replacement path is an explicit trigger in the description.
+
+- id: pos-gs-first-put-get
+  prompt: >-
+    Write me the smallest possible Python program that connects to my local
+    Aerospike and does one write and one read.
+  expect: aerospike
+  domain: aerospike-getting-started
+  why: First put/get with an official SDK.
+
+- id: pos-dev-cdt-map-update
+  prompt: >-
+    I have an Aerospike bin holding a map of vehicle IDs to their last known
+    positions. How do I update one entry without reading and rewriting the whole
+    map?
+  expect: aerospike
+  domain: aerospike-development
+  why: Server-side collection operations are the development core.
+
+- id: pos-dev-batch-reads
+  prompt: >-
+    What's the right way to read four hundred Aerospike records by key in one go
+    from the Go client?
+  expect: aerospike
+  domain: aerospike-development
+  why: Batch workflows and client policy.
+
+- id: pos-dev-policy-timeouts
+  prompt: >-
+    Our Aerospike writes intermittently time out under load. Which client policy
+    settings should I be looking at?
+  expect: aerospike
+  domain: aerospike-development
+  why: Client policies and retry behavior.
+
+- id: pos-dev-secondary-index
+  prompt: >-
+    Should I add a secondary index on the email bin so I can look users up by
+    email in Aerospike?
+  expect: aerospike
+  domain: aerospike-development
+  why: Index discipline, a rule with a strong opinion.
+
+- id: pos-dm-greenfield-schema
+  prompt: >-
+    We're building a social feed on Aerospike and haven't designed the data model
+    yet. Users, posts, follows, likes. Where do I start?
+  expect: aerospike
+  domain: aerospike-data-modeling
+  why: Design-time modeling from requirements.
+
+- id: pos-dm-key-design
+  prompt: >-
+    How should I choose primary keys for an Aerospike set that stores one record
+    per user per day?
+  expect: aerospike
+  domain: aerospike-data-modeling
+  why: Key design is a design-time decision.
+
+- id: pos-dm-unbounded-collection
+  prompt: >-
+    My Aerospike record has a list bin of every event a user has ever fired and
+    it keeps growing. Is that a problem?
+  expect: aerospike
+  domain: aerospike-data-modeling
+  why: Unbounded collection growth is one of the seven failure modes.
+
+- id: pos-dm-schema-review
+  prompt: >-
+    Here's the Aerospike schema we drafted: one set per entity, six secondary
+    indexes, a bin per tag. Can you review it before we build?
+  expect: aerospike
+  domain: aerospike-data-modeling
+  why: Schema review against the failure-mode checklist.

--- a/tests/unit/test_ci_workflows.py
+++ b/tests/unit/test_ci_workflows.py
@@ -1,0 +1,64 @@
+"""Guards for CI mistakes that got past review.
+
+The common shape is a fact restated in two places, then drifting.
+"""
+
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+TESTS = REPO_ROOT / "tests"
+
+
+def test_skill_validator_workflow_delegates_to_the_script():
+    """`skill-validator check` takes exactly one path.
+
+    The workflow used to pass `skills/ compiled-skills/` and was rejected with
+    "accepts 1 arg(s), received 2". Calling the script instead keeps the root
+    list and the compiled-skills link-skip in one place.
+    """
+    text = (WORKFLOWS / "skill-validator.yml").read_text(encoding="utf-8")
+
+    direct_calls = re.findall(r"^\s*skill-validator check\b.*$", text, re.MULTILINE)
+
+    assert direct_calls == []
+    assert "./scripts/validate-skill.sh --ci" in text
+    assert "./scripts/validate-skill.sh --summary" in text
+
+
+def test_no_workflow_expects_a_model_api_key():
+    """Trigger accuracy is measured by hand, by decision, not by omission.
+
+    This project does not put a model API key in CI, so the measurement is a
+    documented pre-publish step. A workflow reaching for the key would either
+    fail on every run or quietly skip and gate nothing.
+    """
+    offenders = [
+        path.name
+        for path in sorted(WORKFLOWS.glob("*.yml"))
+        if "CURSOR_API_KEY" in path.read_text(encoding="utf-8")
+    ]
+
+    assert offenders == []
+
+
+def test_the_documented_trigger_threshold_is_the_one_people_run():
+    """The bar and the command that enforces it must not drift apart.
+
+    `tests/triggers/README.md` explains where the number came from; the
+    pre-publish checklist is what someone actually types. If they disagree, the
+    explanation is describing a check nobody runs.
+    """
+    documented = re.search(
+        r"The bar is \*\*([\d.]+)\*\*",
+        (TESTS / "triggers" / "README.md").read_text(encoding="utf-8"),
+    )
+    invoked = re.search(
+        r"run_triggers\.py[^\n]*--min-accuracy ([\d.]+)",
+        (TESTS / "README.md").read_text(encoding="utf-8"),
+    )
+
+    assert documented is not None
+    assert invoked is not None
+    assert float(invoked.group(1)) == float(documented.group(1))

--- a/tests/unit/test_compile_published_skill.py
+++ b/tests/unit/test_compile_published_skill.py
@@ -1,0 +1,91 @@
+"""The compiled artifact is what registries fetch, so it must be a valid skill:
+frontmatter they can parse, a name matching its folder, and a header that tells
+an agent where the rule files it cites actually live."""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPEC_KEYS = {
+    "name",
+    "description",
+    "license",
+    "compatibility",
+    "metadata",
+    "allowed-tools",
+}
+
+
+def _load_compiler():
+    spec = importlib.util.spec_from_file_location(
+        "compile_agents", REPO_ROOT / "scripts" / "compile-agents.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def compiler():
+    return _load_compiler()
+
+
+@pytest.fixture(scope="module")
+def published(compiler):
+    outputs = compiler.compile_outputs("stripped", compiler.DEFAULT_SKILLS, "single")
+    return outputs, outputs[compiler.SINGLE_OUT]
+
+
+def test_published_skill_lands_in_a_folder_named_after_the_skill(compiler):
+    assert compiler.SINGLE_OUT == "compiled-skills/aerospike/SKILL.md"
+
+
+def test_skills_md_is_no_longer_emitted(published):
+    outputs, _ = published
+    assert "compiled-skills/SKILLS.md" not in outputs
+
+
+def test_frontmatter_parses_and_uses_only_spec_keys(compiler, published):
+    from scripts.skills_compile.skillsrc import split_frontmatter
+
+    _, text = published
+    meta, _body = split_frontmatter(text)
+
+    assert meta, "SKILL.md must open with a YAML frontmatter block"
+    assert set(meta) <= SPEC_KEYS
+    assert meta["name"] == "aerospike"
+    assert meta["license"] == "Apache-2.0"
+    assert isinstance(meta["metadata"]["last_verified"], str)
+
+
+def test_description_covers_all_three_source_domains(published):
+    _, text = published
+    lowered = text[: text.index("---", 4)].lower()
+
+    for term in ("docker", "client code", "data model"):
+        assert term in lowered, f"description should mention {term!r}"
+    for excluded in ("graph", "xdr"):
+        assert excluded in lowered, f"description should rule out {excluded!r}"
+
+
+def test_header_carries_the_repository_url_for_cited_rule_files(compiler, published):
+    _, text = published
+    assert compiler.REPO_URL in text
+    assert "`skills/<skill>/` or its `references/` folder" in text
+
+
+def test_body_is_the_stripped_render(compiler, published):
+    _, text = published
+    skills = [
+        compiler.skillsrc.load_skill(compiler.REPO_ROOT / src)
+        for src in compiler.DEFAULT_SKILLS
+    ]
+    expected_body = compiler.RENDERERS["stripped"](skills).strip()
+    expected = (
+        f"{compiler._frontmatter()}\n"
+        f"{compiler._header(compiler.DEFAULT_SKILLS)}\n"
+        f"{expected_body}\n"
+    )
+    assert text == expected

--- a/tests/unit/test_docs_references.py
+++ b/tests/unit/test_docs_references.py
@@ -1,0 +1,63 @@
+"""No document may point at the retired SKILLS.md, and the install table must
+cover every platform we claim to support."""
+
+import json
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TRACKED_SUFFIXES = {".md", ".json", ".yml", ".sh", ".py"}
+SKIP_DIRS = {".git", "eval", "results", ".venv", ".superpowers"}
+
+# These name the retired path on purpose: one asserts the compiler no longer
+# emits it, and the other is this guard's own search string.
+SKIP_FILES = {
+    "tests/unit/test_compile_published_skill.py",
+    "tests/unit/test_docs_references.py",
+}
+
+
+def _tracked_files():
+    for path in REPO_ROOT.rglob("*"):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel in SKIP_FILES:
+            continue
+        if any(rel == d or rel.startswith(f"{d}/") for d in SKIP_DIRS):
+            continue
+        if path.is_file() and path.suffix in TRACKED_SUFFIXES:
+            yield rel, path
+
+
+def test_nothing_references_the_retired_compiled_file():
+    offenders = [
+        rel
+        for rel, path in _tracked_files()
+        if "compiled-skills/SKILLS.md" in path.read_text(encoding="utf-8")
+        or "](SKILLS.md)" in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == []
+
+
+def test_install_docs_cover_claude_cursor_and_gemini_cli():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    compiled = (REPO_ROOT / "compiled-skills" / "README.md").read_text(encoding="utf-8")
+    assert "-a gemini-cli" in readme, "README must document the Gemini CLI install"
+    for flag in ("-a claude-code", "-a cursor", "-a gemini-cli"):
+        assert flag in compiled, f"compiled-skills README must document {flag}"
+
+
+def test_registry_manifest_lists_the_single_published_skill():
+    manifest = json.loads((REPO_ROOT / "skills.sh.json").read_text(encoding="utf-8"))
+    skills = [s for g in manifest["groupings"] for s in g["skills"]]
+    assert skills == ["aerospike"]
+
+
+def test_install_docs_point_users_at_the_compiled_skill_only():
+    """Registries and install docs must not treat the authoring folders as products."""
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    compiled = (REPO_ROOT / "compiled-skills" / "README.md").read_text(encoding="utf-8")
+
+    for text in (readme, compiled):
+        assert "compiled-skills/aerospike" in text
+        assert "npx skills add aerospike/agent-skills" not in text
+        assert "Copy `skills/aerospike" not in text
+        assert ".cursor/skills/<skill-folder-name>" not in text

--- a/tests/unit/test_payload_integrity.py
+++ b/tests/unit/test_payload_integrity.py
@@ -1,0 +1,45 @@
+"""What we hand a registry must be self-contained and current: a skill folder
+that links outside itself is broken the moment it is installed on its own."""
+
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SKILL_DIRS = sorted(p.parent for p in REPO_ROOT.glob("skills/*/SKILL.md")) + [
+    REPO_ROOT / "compiled-skills" / "aerospike"
+]
+# Markdown links, minus anything that is not a repository-relative path.
+LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def _relative_targets(text):
+    for target in LINK.findall(text):
+        target = target.split("#", 1)[0].strip()
+        if not target or "://" in target or target.startswith("mailto:"):
+            continue
+        yield target
+
+
+@pytest.mark.parametrize("skill_dir", SKILL_DIRS, ids=lambda p: p.name)
+def test_no_skill_links_outside_its_own_folder(skill_dir):
+    escapes = []
+    for md in sorted(skill_dir.rglob("*.md")):
+        for target in _relative_targets(md.read_text(encoding="utf-8")):
+            resolved = (md.parent / target).resolve()
+            if skill_dir.resolve() not in resolved.parents and resolved != skill_dir:
+                escapes.append(f"{md.relative_to(REPO_ROOT)} -> {target}")
+
+    assert escapes == []
+
+
+@pytest.mark.parametrize("skill_dir", SKILL_DIRS, ids=lambda p: p.name)
+def test_every_relative_link_resolves_to_a_file_that_exists(skill_dir):
+    missing = []
+    for md in sorted(skill_dir.rglob("*.md")):
+        for target in _relative_targets(md.read_text(encoding="utf-8")):
+            if not (md.parent / target).exists():
+                missing.append(f"{md.relative_to(REPO_ROOT)} -> {target}")
+
+    assert missing == []

--- a/tests/unit/test_publish_scripts.py
+++ b/tests/unit/test_publish_scripts.py
@@ -1,0 +1,67 @@
+"""Both registries must receive exactly one submission: the compiled skill."""
+
+import json
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_URL = "https://github.com/aerospike/agent-skills"
+
+
+def _run(script, *args):
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / script), "--repo-url", REPO_URL, "--dry-run", *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def test_openagentskill_submits_only_the_compiled_skill():
+    out = _run("publish-openagentskill.sh")
+
+    assert out.count("DRY RUN") == 1
+    assert "DRY RUN aerospike:" in out
+    for retired in ("aerospike-getting-started", "aerospike-development"):
+        assert retired not in out
+
+
+def test_openagentskill_payload_points_at_the_compiled_skill():
+    out = _run("publish-openagentskill.sh")
+    payload = json.loads(out[out.index("{"):out.rindex("}") + 1])
+
+    assert payload["repository"] == REPO_URL
+    assert payload["skillPath"] == "compiled-skills/aerospike/SKILL.md"
+    assert payload["submissionSource"] == "agent"
+
+
+def test_upskill_submits_only_the_compiled_skill():
+    out = _run("publish-upskill.sh", "--ref", "main")
+
+    assert out.count("DRY RUN") == 1
+    assert f"{REPO_URL}/tree/main/compiled-skills/aerospike" in out
+    assert "/skills/aerospike-development" not in out
+
+
+@pytest.mark.parametrize("script", ["publish-openagentskill.sh", "publish-upskill.sh"])
+def test_scripts_fail_when_the_compiled_skill_is_absent(script, tmp_path):
+    """A missing artifact must fail loudly rather than report a successful no-op.
+
+    Each script derives its root from its own location, so copying scripts/ alone
+    into an empty tree is what makes the compiled skill genuinely absent.
+    """
+    shutil.copytree(REPO_ROOT / "scripts", tmp_path / "scripts")
+
+    result = subprocess.run(
+        [str(tmp_path / "scripts" / script), "--repo-url", REPO_URL, "--dry-run"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "compile-agents.py --write" in result.stderr

--- a/tests/unit/test_run_triggers.py
+++ b/tests/unit/test_run_triggers.py
@@ -1,0 +1,211 @@
+"""The trigger runner's corpus handling, verdict parsing, and scoring must be
+correct without a model in the loop, so they are tested with recorded verdicts."""
+
+import json
+import pathlib
+import textwrap
+
+import pytest
+
+from tests.run_triggers import (
+    NO_SKILL,
+    Metrics,
+    TriggerCase,
+    build_router_prompt,
+    load_corpus,
+    load_published_skill,
+    main,
+    parse_verdict,
+    score,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CORPUS_DIR = REPO_ROOT / "tests" / "triggers"
+
+
+def _write_corpus(tmp_path, body):
+    (tmp_path / "cases.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
+    return tmp_path
+
+
+def test_load_corpus_reads_every_yaml_file_and_normalizes_whitespace(tmp_path):
+    _write_corpus(
+        tmp_path,
+        """
+        - id: a
+          prompt: >-
+            one
+            two
+          expect: aerospike
+          domain: aerospike-development
+          why: because
+        """,
+    )
+
+    cases = load_corpus(tmp_path)
+
+    assert cases == [
+        TriggerCase(
+            id="a",
+            prompt="one two",
+            expect="aerospike",
+            domain="aerospike-development",
+            why="because",
+        )
+    ]
+
+
+def test_load_corpus_rejects_a_duplicate_id(tmp_path):
+    _write_corpus(
+        tmp_path,
+        """
+        - id: a
+          prompt: one
+          expect: none
+        - id: a
+          prompt: two
+          expect: none
+        """,
+    )
+
+    with pytest.raises(ValueError, match="duplicate case id: a"):
+        load_corpus(tmp_path)
+
+
+def test_load_corpus_rejects_an_unknown_expectation(tmp_path):
+    _write_corpus(
+        tmp_path,
+        """
+        - id: a
+          prompt: one
+          expect: maybe
+        """,
+    )
+
+    with pytest.raises(ValueError, match="expect must be"):
+        load_corpus(tmp_path)
+
+
+def test_load_corpus_rejects_an_empty_directory(tmp_path):
+    with pytest.raises(ValueError, match="no trigger cases"):
+        load_corpus(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("aerospike", "aerospike"),
+        ("  aerospike.  ", "aerospike"),
+        ("none", NO_SKILL),
+        ("**none**", NO_SKILL),
+        ("I would load aerospike for this.", "aerospike"),
+        ("Probably not relevant, so none.", NO_SKILL),
+        ("", "unparseable"),
+        ("I am not sure", "unparseable"),
+    ],
+)
+def test_parse_verdict_tolerates_the_ways_models_actually_reply(raw, expected):
+    assert parse_verdict(raw, "aerospike") == expected
+
+
+def test_score_counts_each_outcome_and_records_failures():
+    cases = [
+        TriggerCase("p1", "x", "aerospike"),
+        TriggerCase("p2", "x", "aerospike"),
+        TriggerCase("n1", "x", NO_SKILL),
+        TriggerCase("n2", "x", NO_SKILL),
+    ]
+    verdicts = {
+        "p1": "aerospike",
+        "p2": NO_SKILL,
+        "n1": NO_SKILL,
+        "n2": "aerospike",
+    }
+
+    metrics = score(cases, verdicts, "aerospike")
+
+    assert (metrics.total, metrics.correct) == (4, 2)
+    assert metrics.accuracy == 0.5
+    assert (metrics.true_positives, metrics.false_positives) == (1, 1)
+    assert metrics.false_negatives == 1
+    assert metrics.precision == 0.5
+    assert metrics.recall == 0.5
+    assert metrics.failures == (("p2", "aerospike", NO_SKILL), ("n2", NO_SKILL, "aerospike"))
+
+
+def test_metrics_do_not_divide_by_zero_on_an_all_negative_corpus():
+    cases = [TriggerCase("n1", "x", NO_SKILL)]
+
+    metrics = score(cases, {"n1": NO_SKILL}, "aerospike")
+
+    assert metrics.accuracy == 1.0
+    assert metrics.precision == 0.0
+    assert metrics.recall == 0.0
+
+
+def test_router_prompt_carries_the_description_and_offers_only_two_answers():
+    prompt = build_router_prompt("aerospike", "Covers Docker and modeling.", "how do I start?")
+
+    assert "Covers Docker and modeling." in prompt
+    assert "how do I start?" in prompt
+    assert "aerospike" in prompt
+    assert NO_SKILL in prompt
+
+
+def test_load_published_skill_reads_the_shipped_description():
+    name, description = load_published_skill(
+        REPO_ROOT / "compiled-skills" / "aerospike" / "SKILL.md"
+    )
+
+    assert name == "aerospike"
+    assert "Aerospike" in description
+    assert "\n" not in description
+
+
+def test_the_committed_corpus_loads_and_covers_all_three_domains():
+    cases = load_corpus(CORPUS_DIR)
+    domains = {c.domain for c in cases if c.expect == "aerospike"}
+
+    assert len(cases) >= 20
+    assert domains == {
+        "aerospike-getting-started",
+        "aerospike-development",
+        "aerospike-data-modeling",
+    }
+    assert any(c.expect == NO_SKILL for c in cases)
+
+
+def test_main_scores_a_recorded_run_offline_and_gates_on_the_threshold(tmp_path):
+    corpus = _write_corpus(
+        tmp_path,
+        """
+        - id: a
+          prompt: one
+          expect: aerospike
+          domain: aerospike-development
+        - id: b
+          prompt: two
+          expect: none
+        """,
+    )
+    recorded = tmp_path / "verdicts.json"
+    recorded.write_text(json.dumps({"a": "aerospike", "b": "aerospike"}), encoding="utf-8")
+    report = tmp_path / "report.json"
+
+    failing = main(
+        [
+            "--corpus", str(corpus),
+            "--offline", str(recorded),
+            "--min-accuracy", "0.9",
+            "--json", str(report),
+        ]
+    )
+    passing = main(
+        ["--corpus", str(corpus), "--offline", str(recorded), "--min-accuracy", "0.4"]
+    )
+
+    assert failing == 1
+    assert passing == 0
+    written = json.loads(report.read_text(encoding="utf-8"))
+    assert written["accuracy"] == 0.5
+    assert written["failures"] == [["b", "none", "aerospike"]]

--- a/tests/unit/test_skill_metadata.py
+++ b/tests/unit/test_skill_metadata.py
@@ -1,0 +1,32 @@
+"""Every skill declares the server range its guidance targets, so "matches
+current server behavior" has something concrete to be checked against."""
+
+import pathlib
+
+import pytest
+
+from scripts.skills_compile.skillsrc import split_frontmatter
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SKILL_FILES = sorted(REPO_ROOT.glob("skills/*/SKILL.md")) + [
+    REPO_ROOT / "compiled-skills" / "aerospike" / "SKILL.md"
+]
+
+
+def _ids(path):
+    return path.parent.name
+
+
+@pytest.mark.parametrize("skill_md", SKILL_FILES, ids=_ids)
+def test_skill_declares_the_supported_server_range(skill_md):
+    meta, _body = split_frontmatter(skill_md.read_text(encoding="utf-8"))
+
+    assert meta["metadata"]["server_versions"] == "7.0+"
+
+
+def test_every_skill_on_disk_is_covered():
+    """Guards the parametrize list: a new skill folder must not slip past."""
+    on_disk = set(REPO_ROOT.glob("skills/*/SKILL.md"))
+
+    assert on_disk <= set(SKILL_FILES)
+    assert len(SKILL_FILES) == 4

--- a/tests/unit/test_skillsrc.py
+++ b/tests/unit/test_skillsrc.py
@@ -1,0 +1,72 @@
+"""The reference-file parser must treat only the template's five labels as
+section boundaries. Bold content lines are content, not headings."""
+
+from scripts.skills_compile.skillsrc import labeled_sections
+
+
+def test_bolded_url_line_does_not_split_the_rule():
+    body = (
+        "**Rule**\n\n"
+        "The full process lives in the\n"
+        "**`https://github.com/aerospike/data-modeling-guide`**\n"
+        "repository. Fetch it and follow its checklist.\n\n"
+        "**Prefer**\n\n"
+        "- Reading current values from the guide\n"
+    )
+
+    sections = labeled_sections(body)
+
+    assert set(sections) == {"Rule", "Prefer"}
+    assert "data-modeling-guide" in sections["Rule"]
+    assert sections["Rule"].endswith("Fetch it and follow its checklist.")
+
+
+def test_bolded_enumerated_headings_stay_inside_the_rule():
+    body = (
+        "**Rule**\n\n"
+        "Each failure mode below has a detection test.\n\n"
+        "**1. Record granularity from the entity list.**\n"
+        "*Detect:* count the sets.\n\n"
+        "**2. Secondary indexes as the primary query mechanism.**\n"
+        "*Detect:* list every access pattern.\n\n"
+        "**Avoid**\n\n"
+        "- Running these only at the end\n"
+    )
+
+    sections = labeled_sections(body)
+
+    assert set(sections) == {"Rule", "Avoid"}
+    assert "1. Record granularity" in sections["Rule"]
+    assert "2. Secondary indexes" in sections["Rule"]
+
+
+def test_bolded_gotcha_heading_stays_inside_the_avoid_list():
+    body = (
+        "**Avoid**\n\n"
+        "- Reading a whole record when one bin will do\n\n"
+        "**Gotcha: bin-scoped ops vs whole-record reads**\n"
+        "A bin-scoped operation still reads the whole record from device.\n"
+    )
+
+    sections = labeled_sections(body)
+
+    assert set(sections) == {"Avoid"}
+    assert "Gotcha" in sections["Avoid"]
+
+
+def test_all_five_canonical_labels_still_split():
+    body = (
+        "**Rule**\n\nR\n\n"
+        "**Why**\n\nW\n\n"
+        "**Prefer**\n\n- p\n\n"
+        "**Avoid**\n\n- a\n\n"
+        "**See also**\n\n- s\n"
+    )
+
+    assert set(labeled_sections(body)) == {
+        "Rule",
+        "Why",
+        "Prefer",
+        "Avoid",
+        "See also",
+    }

--- a/tests/unit/test_task_corpus.py
+++ b/tests/unit/test_task_corpus.py
@@ -1,0 +1,79 @@
+"""The task corpus is consumed by a harness in another repository, so its shape
+is validated here rather than discovered there."""
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TASKS_DIR = REPO_ROOT / "tests" / "tasks"
+SCHEMA_KEYS = {
+    "id",
+    "prompt",
+    "skill",
+    "category",
+    "required_all",
+    "required_any",
+    "forbidden",
+    "rubric",
+    "expected_refs",
+    "blacklist_targets",
+    "weight",
+}
+
+
+def _tasks():
+    for path in sorted(TASKS_DIR.glob("*.yaml")):
+        for entry in yaml.safe_load(path.read_text(encoding="utf-8")) or []:
+            yield path.name, entry
+
+
+def test_the_corpus_is_not_empty():
+    assert list(_tasks())
+
+
+@pytest.mark.parametrize(
+    "filename,task",
+    list(_tasks()),
+    ids=lambda v: v["id"] if isinstance(v, dict) else v,
+)
+def test_task_uses_only_schema_keys(filename, task):
+    assert set(task) <= SCHEMA_KEYS, f"{task['id']} in {filename}"
+
+
+def test_task_ids_are_unique():
+    ids = [task["id"] for _name, task in _tasks()]
+
+    assert len(ids) == len(set(ids))
+
+
+def test_every_regex_field_compiles():
+    bad = []
+    for _name, task in _tasks():
+        for field in ("required_all", "required_any", "forbidden"):
+            for pattern in task.get(field, []):
+                try:
+                    re.compile(pattern)
+                except re.error as exc:
+                    bad.append(f"{task['id']}.{field}: {pattern!r} ({exc})")
+
+    assert bad == []
+
+
+def test_expected_refs_name_files_that_exist():
+    missing = []
+    for _name, task in _tasks():
+        skill_dir = REPO_ROOT / "skills" / task["skill"]
+        for ref in task.get("expected_refs", []):
+            if not (skill_dir / "references" / ref).exists() and not (skill_dir / ref).exists():
+                missing.append(f"{task['id']} -> {ref}")
+
+    assert missing == []
+
+
+def test_data_modeling_is_covered():
+    skills = {task["skill"] for _name, task in _tasks()}
+
+    assert "aerospike-data-modeling" in skills


### PR DESCRIPTION
## Summary

Single PR replacing the stacked #20 / #21 / #22 chain. Ships one compiled skill (`compiled-skills/aerospike/SKILL.md`), wires registry publishing behind four gates, and adds the checks needed before we point registries and docs at it.

- **Publish shape:** retire `compiled-skills/SKILLS.md`; compile a spec-valid artifact with YAML frontmatter; submit only that file to openagentskill and upskill on release ([`docs/PUBLISHING.md`](docs/PUBLISHING.md))
- **CI:** spec conformance (`skills-ref`), skill-validator, compile drift check, unit tests (65), payload integrity
- **Skill fixes:** parser only splits canonical section labels; `metadata.server_versions: "7.0+"` on all skills; widened published description for data-modeling triggers; two Python API drifts fixed in authoring refs
- **Pre-publish checks (manual):** trigger accuracy (`tests/run_triggers.py`), server claims (`tests/content/verify-server-claims.sh`), live eval vs no-skill baseline — last run on `composer-2.5` (`fast=false`): published **96.7%** vs baseline **95.1%** overall; data-modeling **99.0%** vs **92.9%**
- **Eval harness inputs:** seven data-modeling tasks in `tests/tasks/data-modeling.yaml`

Internal planning docs and the findings ledger were dropped; operational notes live in [`tests/README.md`](tests/README.md).

## Test plan

- [x] `python3 -m pytest tests/unit -v` (65 passed)
- [x] `python3 scripts/compile-agents.py --shape stripped --check`
- [ ] CI: conformance, validate, drift-check, unit
- [ ] Manual before merge: trigger accuracy ≥ 0.88, server claims script clean