### PR TITLE
docs: remove references to the internal evaluation repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The **canonical list of skills** (and what to copy) is [`skills/README.md`](skil
 | [compiled-skills/aerospike/SKILL.md](compiled-skills/aerospike/SKILL.md) | Published agent skill, compiled from `skills/` into one file |
 | [.github/copilot-instructions.md](.github/copilot-instructions.md) | GitHub Copilot repository instructions |
 
-Skill packaging evaluation (structure A/B tests, coverage gates) lives in the separate [agent-skills-eval](https://github.com/citrusleaf/agent-skills-eval) repository.
+Skill packaging evaluation (structure A/B tests, coverage gates) runs in a separate harness repository and is not part of this repository's checks.
 
 The **canonical** `aerospike.conf` and commands for local setup live in [`skills/aerospike-getting-started/SKILL.md`](skills/aerospike-getting-started/SKILL.md) (not duplicated here).
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@
 | `unit/test_payload_integrity.py` | That every skill folder is self-contained — no link leaves its own folder, and every relative link resolves | `python3 -m pytest tests/unit/test_payload_integrity.py -v` |
 | `triggers/` | Whether the published description fires on the right prompts | `python3 tests/run_triggers.py` — see [`triggers/README.md`](triggers/README.md) |
 | `content/verify-server-claims.sh` | The getting-started skill's claims against a real server | `./tests/content/verify-server-claims.sh` (needs Docker) |
-| `tasks/` | End-to-end task prompts, read by the evaluation harness through its submodule | `python3 -m pytest tests/unit/test_task_corpus.py -v` for their shape; the prompts themselves run in [`agent-skills-eval`](https://github.com/citrusleaf/agent-skills-eval) |
+| `tasks/` | End-to-end task prompts, read by the evaluation harness through its submodule | `python3 -m pytest tests/unit/test_task_corpus.py -v` for their shape; the prompts themselves run in the separate evaluation harness |
 
 `verify-server-claims.sh` boots `aerospike/aerospike-server:latest`, the Community image the
 skill tells a new user to run, and removes the container when it exits. Pass `--tag` to check
@@ -36,7 +36,7 @@ python3 tests/run_triggers.py --model composer-2.5 --min-accuracy 0.88
 
 These are not automated, and nothing in CI will notice if they are skipped.
 
-- **A live evaluation run** in [`agent-skills-eval`](https://github.com/citrusleaf/agent-skills-eval). Compare `v0_baseline` (no skill) against `v5_published` (the shipped artifact). Check `n_tasks` against the expected total — a stale submodule pointer silently scores the old corpus. Last measured 2026-08-20 on `composer-2.5` (`fast=false`): published **96.7%** vs baseline **95.1%** overall; data-modeling tasks **99.0%** vs **92.9%**.
+- **A live evaluation run** in the separate evaluation harness. Compare `v0_baseline` (no skill) against `v5_published` (the shipped artifact). Check `n_tasks` against the expected total — a stale submodule pointer silently scores the old corpus. Last measured 2026-08-20 on `composer-2.5` (`fast=false`): published **96.7%** vs baseline **95.1%** overall; data-modeling tasks **99.0%** vs **92.9%**.
 - **The client API signature pass.** Compare the constructor, `put`, `get`, `operate`, and the batch read entry point in each skill's `examples.md` and `references/` against current official SDK documentation. Record the date, the SDK versions, and anything that drifted.
 - **These two URLs resolve** (skill-validator skips link checks on `compiled-skills/`; both 404 until the repositories are public):
   - `https://github.com/aerospike/agent-skills`

--- a/tests/tasks/data-modeling.yaml
+++ b/tests/tasks/data-modeling.yaml
@@ -1,6 +1,6 @@
 # End-to-end tasks for aerospike-data-modeling, the skill no evaluation run has
-# ever measured. Schema matches the harness in aerospike/agent-skills-eval,
-# which reads this file through its vendor/agent-skills submodule.
+# ever measured. Schema matches the separate evaluation harness, which reads
+# this file through its vendor/agent-skills submodule.
 #
 # Regex fields are case-insensitive and searched against the whole output, so a
 # `forbidden` pattern that matches vocabulary the prompt itself invites fails


### PR DESCRIPTION
## Summary

- Removes the repository name and URL of the internal evaluation harness (`citrusleaf/agent-skills-eval`) from `README.md`, `tests/README.md`, and the header comment in `tests/tasks/data-modeling.yaml`.
- The surrounding guidance is unchanged: the docs still explain that packaging evaluation and the end-to-end task prompts run in a separate harness that consumes `tests/tasks/` through a `vendor/agent-skills` submodule, and the manual "live evaluation run" check still describes the `v0_baseline` vs `v5_published` comparison and the last measured numbers. Only the internal identifier and link are gone.

## Test plan

- [x] `git grep -i "agent-skills-eval\|citrusleaf"` returns nothing.
- [x] `python3 -m pytest tests/unit -v` — 65 passed (includes `test_docs_references.py`, which checks documentation links).