### PR TITLE
ci: [AIE-18] add a pr title hygiene check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-<!-- PR titles often follow: type(scope): [JIRA-123] description
-     Examples: feat(api): [ENG-456] add user endpoint
-               fix: [INFRA-789] correct deploy path
-     Some PR types, allowlisted patterns, or the `skip-jira` label are exceptions.
+<!-- PR titles follow conventional commit format: type(scope): description
+     Examples: feat(skills): add an aerospike-operations skill
+               fix: correct the TTL example in aerospike-getting-started
+     No JIRA reference is required.
      See CONTRIBUTING.md for the full title rules. -->
 
 # Description

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,17 @@
+# Validate the PR title as a conventional commit.
+# JIRA is never required here: outside contributors cannot see or open Aerospike tickets.
+name: pr-hygiene
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  hygiene:
+    uses: aerospike/shared-workflows/.github/workflows/reusable_pr-hygiene.yml@0d843cff870d70ac527048ab0d006c7c301fbb2f # v4.1.0
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+      types-requiring-jira: ""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,16 @@ type(scope): description
 
 Common types here are `docs` (skill content), `feat` (a new skill or capability), `fix`, and `chore` (tooling and repo plumbing). The rules come from `@commitlint/config-conventional` via [`commitlint.config.mjs`](commitlint.config.mjs), matching [aerospike/data-modeling-guide](https://github.com/aerospike/data-modeling-guide).
 
+### Pull request titles
+
+The PR title follows the same convention and is checked in CI by
+[`pr-hygiene.yml`](.github/workflows/pr-hygiene.yml), which must pass before
+merge. Dependabot, StepSecurity, and revert titles are allowlisted.
+
+**No JIRA reference is required, on any PR type.** Outside contributors cannot
+see or open Aerospike tickets. Aerospike engineers may include one for their own
+tracking, but no check enforces it.
+
 ### Local hooks
 
 Hooks live in [`.pre-commit-config.yaml`](.pre-commit-config.yaml): secret scanning (gitleaks), shellcheck, whitespace fixes, and commitlint. They are **not** active until you install them:


### PR DESCRIPTION
## Summary

This repository had no CI check on PR titles. Commitlint ran only through
`.pre-commit-config.yaml`, which is opt-in and which an outside contributor
will not have installed, so a non-conventional title reached `main` unchallenged.

Adds the same shared PR-hygiene workflow `data-modeling-guide` uses, configured
the same way: conventional-commit titles enforced, JIRA never required. An
outside contributor cannot see or open an Aerospike JIRA ticket, so a check
demanding one fails a PR for a reason they cannot act on.

## Changes

- new `.github/workflows/pr-hygiene.yml` calling `reusable_pr-hygiene.yml` with `types-requiring-jira: ""`
- `CONTRIBUTING.md`: document the PR title rule alongside the existing commit message rule
- `PULL_REQUEST_TEMPLATE.md`: drop the JIRA title guidance and the `skip-jira` label hint

## Test plan

- `python3 -m pytest tests/unit -q`: 65 passed
- This PR is its own test: the new workflow validates this title
