### PR TITLE
docs: [AIE-20] drop internal-repository wording ahead of publication

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -40,7 +40,7 @@ Gates 2 and 3 **skip with a notice** instead of failing, so a release cut while 
 Prerequisites: the repository is public, and open-source sign-off is recorded on [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
 
 1. Run the workflow manually with `dry_run: true` and confirm the rendered payloads look right. Do this after the repository is public — openagentskill's `/validate` endpoint reads `SKILL.md` over the public URL, so it is the first check that can only pass once we are public.
-2. Create the `registries` environment (**Settings → Environments**) and add the [code owners](../.github/CODEOWNERS) as **required reviewers**. Without reviewers configured, gate 4 does nothing.
+2. Confirm the `registries` environment (**Settings → Environments**) lists the [code owners](../.github/CODEOWNERS) as **required reviewers**. It is configured already; without reviewers, gate 4 does nothing.
 3. Set the repository variable (**Settings → Variables → Actions**): `REGISTRY_PUBLISH_ENABLED` = `true`.
 4. Cut a release, or run the workflow with `dry_run: false`.
 5. Approve the pending environment prompt.

--- a/skills/aerospike-data-modeling/references/ex-guide-escalation.md
+++ b/skills/aerospike-data-modeling/references/ex-guide-escalation.md
@@ -48,9 +48,6 @@ Copying those values into a skill guarantees they go stale, and a stale copy is
 worse than a pointer because nothing signals that it is wrong. Read them from
 the guide at the time you need them.
 
-Both repositories are Aerospike-internal, so access depends on the user's GitHub
-authorization.
-
 **Prefer**
 
 - Reading current values (version minimums, size limits, complexity) from the guide rather than recalling them

--- a/skills/aerospike-development/references/model-record-size-hardware-efficiency.md
+++ b/skills/aerospike-development/references/model-record-size-hardware-efficiency.md
@@ -37,7 +37,7 @@ Modeling ignores index overhead and device I/O until clusters hit **latency**, *
 This band is a design target derived from index-to-data ratio, I/O size, and
 defragmentation cost — not a measured hard boundary. If benchmarking on your
 hardware and workload shows a different range, replace it here with the
-verified figures and note the test conditions. The internal
+verified figures and note the test conditions. The
 `aerospike/data-modeling-guide` repository holds the fuller treatment, including
 the distinction between this target band, the configured `max-record-size`
 limit, and the architectural ceiling.


### PR DESCRIPTION
## Summary

Statements that stop being true when these repositories go public.

## Changes

- `references/ex-guide-escalation.md`: drop "Both repositories are Aerospike-internal, so access depends on the user's GitHub authorization". The `gh repo clone` instruction above it stands on its own
- `references/model-record-size-hardware-efficiency.md`: "The internal `aerospike/data-modeling-guide` repository" loses the adjective
- `docs/PUBLISHING.md`: the `registries` environment now exists with the four code owners as required reviewers, so step 2 is a confirmation rather than a task

Neither skill edit changes `compiled-skills/`: both sentences are stripped from
the compiled artifact. `--shape stripped --check` reports up to date.

## Test plan

- `python3 scripts/compile-agents.py --shape stripped --check`: up to date
- `python3 -m pytest tests/unit -q`: 65 passed
