### PR TITLE
feat(ci): enforce semantic versioning on releases

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -2,9 +2,12 @@
 #
 # This is the only path that contacts a registry. One skill is submitted: the artifact
 # compiled from the three authoring folders under skills/. The first listing and every
-# later refresh run the same reviewed code. It is merged inert and held behind four
+# later refresh run the same reviewed code. It is merged inert and held behind five
 # independent gates; see docs/PUBLISHING.md for the operator's view.
 #
+#   0. Version      - the release tag must be a stable semantic version (vX.Y.Z) above
+#                     every existing tag. A release candidate or a malformed tag fails
+#                     the release build rather than publishing something permanent.
 #   1. Conformance  - the spec-conformance, skill-validator, and compile-agents
 #                     workflows must pass. The last one fails on a stale artifact,
 #                     so a release cannot submit output that lags its sources.
@@ -39,6 +42,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  gate-version:
+    uses: ./.github/workflows/release-version.yml
+
   gate-spec:
     uses: ./.github/workflows/spec-conformance.yml
 
@@ -49,7 +55,7 @@ jobs:
     uses: ./.github/workflows/compile-agents.yml
 
   preflight:
-    needs: [gate-spec, gate-lint, gate-compiled]
+    needs: [gate-version, gate-spec, gate-lint, gate-compiled]
     runs-on: ubuntu-latest
     outputs:
       mode: ${{ steps.decide.outputs.mode }}

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,0 +1,52 @@
+# Enforces the release versioning rules: a stable semantic version, above the last one.
+#
+# Called only by publish-registries.yml, as the gate that runs before any registry is
+# contacted. A release tagged v1.2, v1.2.3-rc.1, or below an existing tag fails here,
+# which fails the release build and publishes nothing.
+#
+# The rules live in scripts/check-release-version.sh so a maintainer can run the same
+# check before cutting the release instead of learning about it afterwards:
+#
+#   ./scripts/check-release-version.sh --tag v1.2.0
+name: release-version
+
+on:
+  # Not a standalone trigger: publish-registries.yml already runs on release, so a
+  # release trigger here would duplicate the check on every release.
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      # Full history. The ordering check compares against every existing tag, and the
+      # default shallow release checkout carries only the tag being released, which
+      # would make every release look like the first one.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check the release tag
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          FLAGGED_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          ./scripts/check-release-version.sh \
+            --tag "${TAG}" \
+            --flagged-prerelease "${FLAGGED_PRERELEASE}"
+
+      # A manual dry run has no release to check. Skipping keeps a rehearsal from
+      # failing on a rule that only applies to releases.
+      - name: Note that a manual run has no tag to check
+        if: github.event_name != 'release'
+        run: |
+          echo "::notice title=Version check skipped::No release tag on a ${GITHUB_EVENT_NAME} run. The versioning rules apply when a release is published."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,13 @@ The commit is pinned because `skills-ref` has no PyPI release. Keep the pin in [
 
 ## Publishing to registries
 
-Submission is automated on release and gated behind conformance, public visibility, a kill-switch variable, and reviewer approval. Do not submit by hand—see [`docs/PUBLISHING.md`](docs/PUBLISHING.md).
+Submission is automated on release and gated behind a stable semantic version tag, conformance, public visibility, a kill-switch variable, and reviewer approval. Do not submit by hand—see [`docs/PUBLISHING.md`](docs/PUBLISHING.md).
+
+Release tags are `vMAJOR.MINOR.PATCH` with no prerelease suffix, and must exceed the previous tag. Check one before cutting a release:
+
+```bash
+./scripts/check-release-version.sh --tag v1.4.0
+```
 
 ## Before you open a pull request
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -6,34 +6,59 @@ This document is for whoever cuts a release, or turns publishing on for the firs
 
 ## How to publish
 
-Cut a GitHub release. That is the whole procedure — then approve the environment prompt when GitHub asks.
+Tag a stable semantic version — `vX.Y.Z`, above the last release — and cut a GitHub release. That is the whole procedure, then approve the environment prompt when GitHub asks. See [Version numbers](#version-numbers) for what the tag has to look like.
 
 To rehearse without submitting anything, run the workflow manually from the Actions tab with **Run workflow**. The `dry_run` input defaults to `true`, which renders the exact payloads into the job summary and contacts nothing.
 
-## The four gates
+## Version numbers
+
+Releases are [semantic versions](https://semver.org/) with a `v` prefix, and [`release-version.yml`](../.github/workflows/release-version.yml) enforces three rules on every release before any gate below is reached:
+
+| Rule | Rejected | Accepted |
+|------|----------|----------|
+| Exactly `vMAJOR.MINOR.PATCH`, no leading zeros | `1.4.0`, `v1.4`, `v1.04.0` | `v1.4.0` |
+| No prerelease suffix, no build metadata, and not flagged **Set as a pre-release** on the release | `v1.4.0-rc.1`, `v1.4.0+build.3` | `v1.4.0` |
+| Above the highest existing tag | `v1.3.9` after `v1.4.0` | `v1.4.1`, `v1.5.0`, `v2.0.0` |
+
+Stability is the rule worth understanding: publishing is **permanent**, because no registry documents a way to delete a submission. A release candidate that reaches a registry cannot be taken back, so a prerelease is not allowed to be a release here. Use a **draft** release to stage notes instead — drafts publish nothing until released.
+
+Check a tag before you cut anything, rather than finding out from a red release build:
+
+```bash
+./scripts/check-release-version.sh --tag v1.4.0
+```
+
+The rules live in that script, not in the workflow, so the local check and the enforced check are the same code.
+
+One gap to know about: a release creates its tag before the check runs, so the ordering rule compares against every *other* tag. Publishing a second release on a tag that already exists therefore reads as new — git cannot distinguish a tag the release just created from one that was already there. Nothing else re-uses a version number, so this is a caveat rather than a hole.
+
+## The five gates
 
 Every gate must pass before a single request leaves the runner.
 
 ```mermaid
 flowchart TD
-    Rel[release published] --> Conf[1: conformance workflows]
+    Rel[release published] --> Ver[0: tag is a stable, increasing semver]
+    Ver --> Conf[1: conformance workflows]
     Conf --> Vis[2: repository is public]
     Vis --> Flag[3: REGISTRY_PUBLISH_ENABLED is true]
     Flag --> Env[4: registries environment approval]
     Env --> Submit[submit to openagentskill + upskill]
-    Conf -->|fail| Fail[workflow fails, nothing submitted]
+    Ver -->|fail| Fail[workflow fails, nothing submitted]
+    Conf -->|fail| Fail
     Vis -->|not public| Skip[skipped with a notice]
     Flag -->|not true| Skip
 ```
 
 | Gate | Mechanism | Why |
 |------|-----------|-----|
+| 0. Version | `needs:` on [`release-version.yml`](../.github/workflows/release-version.yml), which runs [`scripts/check-release-version.sh`](../scripts/check-release-version.sh) | A listing points at a version number people rely on. A malformed tag, a release candidate, or a version that goes backwards must not become a permanent submission. |
 | 1. Conformance | `needs:` on [`spec-conformance.yml`](../.github/workflows/spec-conformance.yml), [`skill-validator.yml`](../.github/workflows/skill-validator.yml), and [`compile-agents.yml`](../.github/workflows/compile-agents.yml) | Never publish a tree that fails the standard, or an artifact that lags the sources it was compiled from. The pull request run does not prove the tag is clean. |
 | 2. Visibility | `gh api repos/... --jq .visibility` must be `public` | Every registry validates a public URL. Submitting a link that 404s wastes our one credible shot with that registry. |
 | 3. Kill switch | Repository variable `REGISTRY_PUBLISH_ENABLED` must be exactly `true` | The deliberate hold, and the rollback. Setting it back to `false` stops all publishing without reverting code. |
 | 4. Approval | The publish job runs in the `registries` environment | Neither registry documents a way to delete a submission, so a human confirms every one. **Permanent, not just for the initial rollout.** |
 
-Gates 2 and 3 **skip with a notice** instead of failing, so a release cut while publishing is held does not produce a red build. Gate 1 fails hard.
+Gates 2 and 3 **skip with a notice** instead of failing, so a release cut while publishing is held does not produce a red build. Gates 0 and 1 fail hard — and they fail even while publishing is held, so a badly numbered release is reported the moment it is cut rather than at the first live publish.
 
 ## Turning publishing on for the first time
 
@@ -42,7 +67,7 @@ Prerequisites: the repository is public, and open-source sign-off is recorded on
 1. Run the workflow manually with `dry_run: true` and confirm the rendered payloads look right. Do this after the repository is public — openagentskill's `/validate` endpoint reads `SKILL.md` over the public URL, so it is the first check that can only pass once we are public.
 2. Confirm the `registries` environment (**Settings → Environments**) lists the [code owners](../.github/CODEOWNERS) as **required reviewers**. It is configured already; without reviewers, gate 4 does nothing.
 3. Set the repository variable (**Settings → Variables → Actions**): `REGISTRY_PUBLISH_ENABLED` = `true`.
-4. Cut a release, or run the workflow with `dry_run: false`.
+4. Cut a release tagged `vX.Y.Z`, or run the workflow with `dry_run: false`.
 5. Approve the pending environment prompt.
 6. Verify each listing URL resolves and record it in the table below.
 

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Check that a release tag is a stable semantic version that moves the project forward.
+#
+# Called by .github/workflows/release-version.yml, the gate publish-registries.yml runs
+# before it contacts a registry. Also runnable by hand before cutting a release:
+#
+#   ./scripts/check-release-version.sh --tag v1.2.0
+#
+# Three rules, checked in this order so the failure names the actual problem:
+#
+#   1. Format    exactly vMAJOR.MINOR.PATCH -- decimal, no leading zeros.
+#   2. Stability no prerelease suffix, no build metadata, and the release is not
+#                flagged as a prerelease on GitHub. A release publishes to registries
+#                and neither registry documents a way to delete a submission, so a
+#                release candidate must not be able to reach one.
+#   3. Ordering  strictly greater than the highest tag already in the repository.
+#                Needs the full tag list, which a shallow checkout does not have.
+#
+# Keep the rules here rather than in the workflow, so cutting a release is not the
+# first time anyone finds out the tag is wrong. See docs/PUBLISHING.md.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAG=""
+FLAGGED_PRERELEASE="false"
+CHECK_ORDERING=1
+
+# The one definition of an acceptable tag. Alternation rather than [0-9]+ rejects the
+# leading zeros the spec forbids: v1.02.3 is not v1.2.3 by another name.
+STABLE='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: check-release-version.sh --tag vX.Y.Z [options]
+
+  --tag TAG                  Release tag to check (required).
+  --flagged-prerelease BOOL  Whether GitHub marked the release a prerelease.
+                             true or false. Default: false
+  --skip-ordering            Check format and stability only. For a tree without
+                             the full tag history.
+EOF
+  exit 2
+}
+
+# Single ? on purpose: an omitted value is a caller bug, but an empty one is what an
+# unset workflow expression looks like, and that deserves this script's own message.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag) TAG="${2?--tag needs a value}"; shift 2 ;;
+    --flagged-prerelease) FLAGGED_PRERELEASE="${2?--flagged-prerelease needs a value}"; shift 2 ;;
+    --skip-ordering) CHECK_ORDERING=0; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+[[ -n "${TAG}" ]] || { echo "--tag is required." >&2; usage; }
+
+# Anything other than the two literals is a caller bug, most likely an unset workflow
+# expression. Rejecting it keeps a typo from reading as "not a prerelease".
+case "${FLAGGED_PRERELEASE}" in
+  true|false) ;;
+  *) echo "--flagged-prerelease takes true or false, got \"${FLAGGED_PRERELEASE}\"." >&2; exit 2 ;;
+esac
+
+# Compares two vX.Y.Z tags numerically. Equal is not newer.
+newer_than() {
+  local IFS=.
+  local -a new old
+  read -r -a new <<<"${1#v}"
+  read -r -a old <<<"${2#v}"
+
+  local i
+  for i in 0 1 2; do
+    if ((new[i] > old[i])); then return 0; fi
+    if ((new[i] < old[i])); then return 1; fi
+  done
+  return 1
+}
+
+if [[ ! "${TAG}" =~ ${STABLE} ]]; then
+  echo "Release tag \"${TAG}\" is not a stable semantic version." >&2
+  echo >&2
+  if [[ "${TAG}" =~ ^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)[-+] ]]; then
+    echo "It carries a prerelease or build suffix. This repository releases stable" >&2
+    echo "versions only, because a release submits to registries and no registry" >&2
+    echo "documents a way to delete a submission." >&2
+  elif [[ "${TAG}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "Add the v prefix: v${TAG}" >&2
+  else
+    echo "Expected exactly vMAJOR.MINOR.PATCH, for example v1.4.0: no prerelease" >&2
+    echo "suffix, no build metadata, no leading zeros, no extra components." >&2
+  fi
+  exit 1
+fi
+
+if [[ "${FLAGGED_PRERELEASE}" == "true" ]]; then
+  echo "Release ${TAG} is flagged as a prerelease on GitHub." >&2
+  echo >&2
+  echo "The tag is well formed, but this repository releases stable versions only." >&2
+  echo "Clear \"Set as a pre-release\" on the release, or cut it as a draft instead:" >&2
+  echo "a draft publishes nothing until it is released." >&2
+  exit 1
+fi
+
+if [[ "${CHECK_ORDERING}" -eq 0 ]]; then
+  echo "${TAG} is a stable semantic version. Ordering not checked (--skip-ordering)."
+  exit 0
+fi
+
+if ! git -C "${ROOT}" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "${ROOT} is not a git repository, so the ordering check cannot run." >&2
+  echo "Pass --skip-ordering to check the tag format alone." >&2
+  exit 3
+fi
+
+# Tags that predate this check, or that some other tooling created, are not the thing
+# being released -- ignore them rather than fail on them.
+highest=""
+while read -r existing; do
+  [[ -n "${existing}" ]] || continue
+  # A release creates its tag before this runs, so the tag under test is already in
+  # the list and cannot be compared against itself. The cost is that re-releasing a
+  # version that already exists reads as new; git cannot tell the two apart.
+  [[ "${existing}" == "${TAG}" ]] && continue
+  [[ "${existing}" =~ ${STABLE} ]] || continue
+  if [[ -z "${highest}" ]] || newer_than "${existing}" "${highest}"; then
+    highest="${existing}"
+  fi
+done < <(git -C "${ROOT}" tag --list 'v*')
+
+if [[ -z "${highest}" ]]; then
+  echo "${TAG} is a stable semantic version, and the first release. Nothing to compare."
+  exit 0
+fi
+
+if ! newer_than "${TAG}" "${highest}"; then
+  echo "Release tag ${TAG} does not move the version forward." >&2
+  echo >&2
+  echo "The highest tag already in this repository is ${highest}. Bump the major," >&2
+  echo "minor, or patch above it. If ${highest} looks wrong, a shallow clone without" >&2
+  echo "the full tag history reports the wrong answer here." >&2
+  exit 1
+fi
+
+echo "${TAG} is a stable semantic version and supersedes ${highest}."

--- a/tests/unit/test_release_version.py
+++ b/tests/unit/test_release_version.py
@@ -1,0 +1,183 @@
+"""Release tags are stable semantic versions that move forward.
+
+The gate is only worth having if it fails on the tags it is meant to catch, so these
+exercise the script itself rather than asserting on its source.
+"""
+
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-release-version.sh"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _check(*args, repo=None):
+    """Run the script, optionally the copy inside a scratch repository."""
+    return subprocess.run(
+        [str(SCRIPT if repo is None else repo / "scripts" / SCRIPT.name), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def tagged_repo(tmp_path):
+    """A copy of scripts/ in a real repository, so tags are the only variable.
+
+    The script derives its root from its own location, which is what makes a copied
+    tree the tag history it reads.
+    """
+    shutil.copytree(REPO_ROOT / "scripts", tmp_path / "scripts")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "-q", "--allow-empty", "-m", "root"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    def tag(*names):
+        for name in names:
+            subprocess.run(["git", "tag", name], cwd=tmp_path, check=True)
+        return tmp_path
+
+    return tag
+
+
+@pytest.mark.parametrize("tag", ["v0.1.0", "v1.4.0", "v10.20.30"])
+def test_stable_versions_pass(tag):
+    result = _check("--tag", tag, "--skip-ordering")
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "1.4.0",  # missing the v prefix
+        "v1.4",  # not three components
+        "v1.4.0.1",
+        "v1.04.0",  # leading zero
+        "v1.x.0",
+        "release-1.4.0",
+        "latest",
+    ],
+)
+def test_malformed_tags_fail(tag):
+    result = _check("--tag", tag, "--skip-ordering")
+
+    assert result.returncode != 0
+    assert "vMAJOR.MINOR.PATCH" in result.stderr or "v prefix" in result.stderr
+
+
+def test_an_empty_tag_reports_a_missing_argument():
+    """What an unset workflow expression looks like, so it needs its own message
+    rather than a shell parameter error."""
+    result = _check("--tag", "", "--skip-ordering")
+
+    assert result.returncode != 0
+    assert "--tag is required" in result.stderr
+
+
+@pytest.mark.parametrize("tag", ["v1.4.0-rc.1", "v1.4.0-beta", "v1.4.0+build.3"])
+def test_prerelease_and_build_metadata_fail(tag):
+    """Stable versions only: a submission cannot be withdrawn from a registry."""
+    result = _check("--tag", tag, "--skip-ordering")
+
+    assert result.returncode != 0
+    assert "stable" in result.stderr
+
+
+def test_a_well_formed_tag_flagged_prerelease_on_github_fails():
+    """The flag matters as much as the tag; either one can mean "not ready"."""
+    result = _check("--tag", "v1.4.0", "--flagged-prerelease", "true", "--skip-ordering")
+
+    assert result.returncode != 0
+    assert "prerelease" in result.stderr
+
+
+def test_an_unresolved_prerelease_expression_is_not_read_as_false():
+    """An empty workflow expression must fail loudly, not silently permit."""
+    result = _check("--tag", "v1.4.0", "--flagged-prerelease", "", "--skip-ordering")
+
+    assert result.returncode != 0
+
+
+def test_the_first_release_has_nothing_to_compare_against(tagged_repo):
+    repo = tagged_repo()
+
+    result = _check("--tag", "v0.1.0", repo=repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "first release" in result.stdout
+
+
+@pytest.mark.parametrize("tag", ["v1.4.1", "v1.5.0", "v2.0.0"])
+def test_increasing_versions_pass(tagged_repo, tag):
+    repo = tagged_repo("v1.0.0", "v1.4.0")
+
+    result = _check("--tag", tag, repo=repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "v1.4.0" in result.stdout
+
+
+@pytest.mark.parametrize("tag", ["v1.3.9", "v0.9.0", "v1.0.0"])
+def test_versions_that_do_not_move_forward_fail(tagged_repo, tag):
+    repo = tagged_repo("v1.0.0", "v1.4.0")
+
+    result = _check("--tag", tag, repo=repo)
+
+    assert result.returncode != 0
+    assert "v1.4.0" in result.stderr
+
+
+def test_ordering_compares_numerically_not_lexically(tagged_repo):
+    """v1.10.0 is above v1.9.0, though it sorts below it as text."""
+    repo = tagged_repo("v1.9.0")
+
+    assert _check("--tag", "v1.10.0", repo=repo).returncode == 0
+    assert _check("--tag", "v1.2.0", repo=repo).returncode != 0
+
+
+def test_the_tag_under_test_is_not_compared_against_itself(tagged_repo):
+    """A release event creates the tag before this check runs, so it is already
+    present in the history it reads. Comparing it to itself would reject every
+    release as "not moving forward"."""
+    repo = tagged_repo("v1.0.0", "v1.4.0", "v1.5.0")
+
+    result = _check("--tag", "v1.5.0", repo=repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "v1.4.0" in result.stdout
+
+
+def test_a_tree_without_tag_history_fails_rather_than_guessing(tmp_path):
+    """Silently treating a missing history as "first release" would wave through
+    any version at all."""
+    shutil.copytree(REPO_ROOT / "scripts", tmp_path / "scripts")
+
+    result = _check("--tag", "v0.0.1", repo=tmp_path)
+
+    assert result.returncode != 0
+    assert "--skip-ordering" in result.stderr
+
+
+def test_the_gate_is_wired_into_publishing():
+    """A gate that no job needs is decorative."""
+    publish = (WORKFLOWS / "publish-registries.yml").read_text(encoding="utf-8")
+
+    assert "uses: ./.github/workflows/release-version.yml" in publish
+    assert "needs: [gate-version," in publish
+
+
+def test_the_version_workflow_fetches_the_full_tag_history():
+    """A shallow release checkout makes every release look like the first one."""
+    workflow = (WORKFLOWS / "release-version.yml").read_text(encoding="utf-8")
+
+    assert "fetch-depth: 0" in workflow
+    assert "check-release-version.sh" in workflow


### PR DESCRIPTION
## Summary

Releases are the trigger for registry publishing, and a registry submission cannot be deleted, so the version number attached to one has to be right the first time. This adds a gate that rejects a release before anything is submitted unless its tag is a stable semantic version that moves the project forward.

Three rules, enforced in `scripts/check-release-version.sh`:

| Rule | Rejected | Accepted |
|------|----------|----------|
| Exactly `vMAJOR.MINOR.PATCH`, no leading zeros | `1.4.0`, `v1.4`, `v1.04.0` | `v1.4.0` |
| No prerelease suffix or build metadata, and not flagged **Set as a pre-release** | `v1.4.0-rc.1`, `v1.4.0+build.3` | `v1.4.0` |
| Above the highest existing tag | `v1.3.9` after `v1.4.0` | `v1.4.1`, `v1.5.0`, `v2.0.0` |

There are no tags or releases in this repository yet, so this defines the convention rather than changing one.

### How it is wired in

- `.github/workflows/release-version.yml` is a `workflow_call`-only workflow, added to the `needs:` of `preflight` in `publish-registries.yml` as gate 0. It checks out with `fetch-depth: 0`, because the default shallow release checkout carries only the tag being released and would make every release look like the first.
- Gate 0 fails hard, and runs even while publishing is held by `REGISTRY_PUBLISH_ENABLED`, so a badly numbered release is reported when it is cut rather than at the first live publish.
- The rules sit in a script rather than inline YAML, matching the existing publish scripts, so a maintainer can check a tag before cutting anything: `./scripts/check-release-version.sh --tag v1.4.0`.
- A manual `workflow_dispatch` dry run has no release to check and skips with a notice instead of failing.

### Known gap, documented in `docs/PUBLISHING.md`

A release creates its tag before the check runs, so the ordering rule compares against every *other* tag. Publishing a second release on a tag that already exists therefore reads as new — git cannot distinguish a tag the release just created from one that was already there.

## Test plan

- [x] `python3 -m pytest tests/unit -v` — 93 passed, including 28 new tests in `tests/unit/test_release_version.py` that run the script against scratch git repositories rather than asserting on its source.
- [x] `shellcheck scripts/check-release-version.sh` — clean.
- [x] All seven workflow files parse as YAML; `publish-registries.yml` resolves `gate-version` alongside the existing gates.
- [x] Manual runs of each failure path produce the intended message (malformed tag, prerelease suffix, prerelease flag, first release).
- [ ] Reviewer confirms the two judgement calls: rejecting a well-formed tag when the release is flagged **Set as a pre-release**, and requiring the `v` prefix rather than accepting bare `1.4.0`.