### PR TITLE
ci: publish to registries without a reviewer approval step

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -2,7 +2,7 @@
 #
 # This is the only path that contacts a registry. One skill is submitted: the artifact
 # compiled from the three authoring folders under skills/. The first listing and every
-# later refresh run the same reviewed code. It is merged inert and held behind five
+# later refresh run the same reviewed code. It is merged inert and held behind four
 # independent gates; see docs/PUBLISHING.md for the operator's view.
 #
 #   0. Version      - the release tag must be a stable semantic version (vX.Y.Z) above
@@ -13,13 +13,15 @@
 #                     so a release cannot submit output that lags its sources.
 #   2. Visibility   - the repository must be public, or a submitted URL would 404.
 #   3. Kill switch  - repository variable REGISTRY_PUBLISH_ENABLED must be "true".
-#   4. Approval     - the publish job runs in the "registries" environment, which
-#                     requires a reviewer. Neither registry documents a way to
-#                     delete a submission, so this gate is permanent, not just a
-#                     safeguard for the initial rollout.
 #
-# Gates 2 and 3 skip with a notice rather than failing: a release cut during the
-# hold period should not report a broken build.
+# There is deliberately no reviewer approval step: a release that clears these four
+# gates publishes on its own. Those gates are the authorization, and re-submission is
+# an idempotent refresh that both scripts treat as success. A first listing still
+# cannot be deleted, so the kill switch is what holds publishing before it starts --
+# leave it unset until the first submission is genuinely intended.
+#
+# Gates 2 and 3 skip with a notice rather than failing: a release cut while publishing
+# is held should not report a broken build.
 name: publish-registries
 
 on:
@@ -95,7 +97,7 @@ jobs:
           fi
 
           echo "mode=publish" >> "$GITHUB_OUTPUT"
-          echo "All gates passed; publishing pends reviewer approval of the registries environment."
+          echo "All gates passed; submitting to registries."
 
   dry-run:
     needs: preflight
@@ -142,9 +144,6 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.mode == 'publish'
     runs-on: ubuntu-latest
-    # Holds the job pending until a reviewer approves. Configure required reviewers
-    # on this environment, or the gate is decorative.
-    environment: registries
     env:
       UPSKILL_VERSION: 0.10.1
       # Submitted tree URLs point at the default branch, not the release tag, so a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ The commit is pinned because `skills-ref` has no PyPI release. Keep the pin in [
 
 ## Publishing to registries
 
-Submission is automated on release and gated behind a stable semantic version tag, conformance, public visibility, a kill-switch variable, and reviewer approval. Do not submit by hand—see [`docs/PUBLISHING.md`](docs/PUBLISHING.md).
+Submission is automated on release and gated behind a stable semantic version tag, conformance, public visibility, and a kill-switch variable. Do not submit by hand—see [`docs/PUBLISHING.md`](docs/PUBLISHING.md).
 
 Release tags are `vMAJOR.MINOR.PATCH` with no prerelease suffix, and must exceed the previous tag. Check one before cutting a release:
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -6,7 +6,7 @@ This document is for whoever cuts a release, or turns publishing on for the firs
 
 ## How to publish
 
-Tag a stable semantic version — `vX.Y.Z`, above the last release — and cut a GitHub release. That is the whole procedure, then approve the environment prompt when GitHub asks. See [Version numbers](#version-numbers) for what the tag has to look like.
+Tag a stable semantic version — `vX.Y.Z`, above the last release — and cut a GitHub release. That is the whole procedure: a release that clears the gates below submits on its own, with nothing to approve. See [Version numbers](#version-numbers) for what the tag has to look like.
 
 To rehearse without submitting anything, run the workflow manually from the Actions tab with **Run workflow**. The `dry_run` input defaults to `true`, which renders the exact payloads into the job summary and contacts nothing.
 
@@ -32,7 +32,7 @@ The rules live in that script, not in the workflow, so the local check and the e
 
 One gap to know about: a release creates its tag before the check runs, so the ordering rule compares against every *other* tag. Publishing a second release on a tag that already exists therefore reads as new — git cannot distinguish a tag the release just created from one that was already there. Nothing else re-uses a version number, so this is a caveat rather than a hole.
 
-## The five gates
+## The four gates
 
 Every gate must pass before a single request leaves the runner.
 
@@ -42,8 +42,7 @@ flowchart TD
     Ver --> Conf[1: conformance workflows]
     Conf --> Vis[2: repository is public]
     Vis --> Flag[3: REGISTRY_PUBLISH_ENABLED is true]
-    Flag --> Env[4: registries environment approval]
-    Env --> Submit[submit to openagentskill + upskill]
+    Flag --> Submit[submit to openagentskill + upskill]
     Ver -->|fail| Fail[workflow fails, nothing submitted]
     Conf -->|fail| Fail
     Vis -->|not public| Skip[skipped with a notice]
@@ -56,20 +55,19 @@ flowchart TD
 | 1. Conformance | `needs:` on [`spec-conformance.yml`](../.github/workflows/spec-conformance.yml), [`skill-validator.yml`](../.github/workflows/skill-validator.yml), and [`compile-agents.yml`](../.github/workflows/compile-agents.yml) | Never publish a tree that fails the standard, or an artifact that lags the sources it was compiled from. The pull request run does not prove the tag is clean. |
 | 2. Visibility | `gh api repos/... --jq .visibility` must be `public` | Every registry validates a public URL. Submitting a link that 404s wastes our one credible shot with that registry. |
 | 3. Kill switch | Repository variable `REGISTRY_PUBLISH_ENABLED` must be exactly `true` | The deliberate hold, and the rollback. Setting it back to `false` stops all publishing without reverting code. |
-| 4. Approval | The publish job runs in the `registries` environment | Neither registry documents a way to delete a submission, so a human confirms every one. **Permanent, not just for the initial rollout.** |
 
 Gates 2 and 3 **skip with a notice** instead of failing, so a release cut while publishing is held does not produce a red build. Gates 0 and 1 fail hard — and they fail even while publishing is held, so a badly numbered release is reported the moment it is cut rather than at the first live publish.
+
+There is no reviewer approval step. A release that clears these four gates submits unattended, which is the point: a correctly versioned release is the authorization, and re-submission is an idempotent refresh. The consequence to respect is that a **first** listing cannot be deleted by any documented means, so gate 3 is what holds publishing until that first submission is genuinely intended.
 
 ## Turning publishing on for the first time
 
 Prerequisites: the repository is public, and open-source sign-off is recorded on [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
 
 1. Run the workflow manually with `dry_run: true` and confirm the rendered payloads look right. Do this after the repository is public — openagentskill's `/validate` endpoint reads `SKILL.md` over the public URL, so it is the first check that can only pass once we are public.
-2. Confirm the `registries` environment (**Settings → Environments**) lists the [code owners](../.github/CODEOWNERS) as **required reviewers**. It is configured already; without reviewers, gate 4 does nothing.
-3. Set the repository variable (**Settings → Variables → Actions**): `REGISTRY_PUBLISH_ENABLED` = `true`.
-4. Cut a release tagged `vX.Y.Z`, or run the workflow with `dry_run: false`.
-5. Approve the pending environment prompt.
-6. Verify each listing URL resolves and record it in the table below.
+2. Set the repository variable (**Settings → Variables → Actions**): `REGISTRY_PUBLISH_ENABLED` = `true`.
+3. Cut a release tagged `vX.Y.Z`, or run the workflow with `dry_run: false`.
+4. Verify each listing URL resolves and record it in the table below.
 
 ## Registries
 


### PR DESCRIPTION
# Description

A properly versioned release should publish on its own. It didn't: the `publish` job ran in the `registries` environment, so every release waited for one of the code owners to approve it before anything reached a registry. This removes that gate, leaving four.

This surfaced when the v1.0.0 release published nothing. That particular run was held by gate 3 (`REGISTRY_PUBLISH_ENABLED` is unset), not by the approval, but it prompted the question of why a correctly versioned release needed a human at all.

The original rationale was that no registry documents a way to delete a submission. That holds for a **first** listing, but not for the refreshes that follow — `publish-openagentskill.sh` explicitly treats a duplicate response as success, and upskill submits a `tree/main` URL that tracks the branch. So the approval was paying a per-release cost for a one-time risk. Gate 3 already covers the one-time case: it holds publishing until the first submission is genuinely intended, and reverts it without a code change.

## Changes

- `publish-registries.yml`: drop `environment: registries` from the `publish` job, drop gate 4 from the header comment, and record why there is no approval step so it isn't restored as a bug fix. Reword the preflight `mode=publish` message, which promised an approval that no longer happens.
- `docs/PUBLISHING.md`: "The five gates" becomes "The four gates" — diagram node, table row, and the "How to publish" line. The first-time checklist loses the two approval steps and is now four steps. Adds a paragraph stating the tradeoff explicitly, so the irreversibility of a first listing is still on the record.
- `CONTRIBUTING.md`: drop reviewer approval from the one-line summary of the gates.

## How to Test

- `python3 -m pytest tests/unit -q` — 93 passed. No test asserted the environment, so nothing needed updating.
- The workflow parses and the `publish` job no longer carries an `environment` key:
  `python3 -c "import yaml; print('environment' in yaml.safe_load(open('.github/workflows/publish-registries.yml'))['jobs']['publish'])"` → `False`
- Confirmed nothing depended on the environment: `repos/.../environments/registries/secrets` and `.../variables` are both empty, and the repository has no Actions secrets. Both registry APIs are unauthenticated, so the publish job only ever needed the implicit token.
- End to end verification requires a real publish, which is still held by gate 3.

## Notes for the reviewer

- The `registries` environment is left configured in **Settings → Environments** with the four code owners as required reviewers. It is now unreferenced dead config rather than a gate, and can be deleted separately.
- **This does not make the next release publish.** `REGISTRY_PUBLISH_ENABLED` is still unset, so gate 3 will hold a release exactly as it held v1.0.0. This PR removes the recurring manual step; setting that variable is the one-time step still outstanding.
- A held publish still reports a green build. That is unchanged here and arguably worth fixing separately, since with no approval prompt the run status is now the only signal.

## Self-Review Checklist

- [x] Code follows project conventions
- [x] Tests added or updated as needed
- [x] No unrelated changes included