### PR TITLE
fix: submit to the canonical openagentskill host and a parseable description

### DIFF
--- a/compiled-skills/aerospike/SKILL.md
+++ b/compiled-skills/aerospike/SKILL.md
@@ -1,19 +1,6 @@
 ---
 name: aerospike
-description: >-
-  Work with the Aerospike core database end to end: run a local instance with
-  Docker and verify a first write and read, build or review client code with the
-  official SDKs (Python, Node.js, Go, Java, C#), and design or review a
-  data model, whether from requirements or against a schema that already
-  exists. Covers namespaces, sets, bins, primary key design, TTL and NSUP,
-  collection data types, expressions, secondary indexes, batch and scan
-  workflows, client policies, connection pooling, record sizing, and schema
-  deliverables. Use when the user sets up Aerospike, writes or debugs Aerospike
-  client code, chooses keys or models data for it, reviews an Aerospike schema
-  before building, or evaluates it as a persistent replacement for Redis or
-  Memcached in real-time, low-latency, feature-store, or user-profile workloads.
-  Core database only: not Aerospike Graph, and not cluster operations, sizing,
-  XDR, or backup and restore, which belong to Aerospike Operations documentation.
+description: Work with the Aerospike core database end to end — run a local instance with Docker and verify a first write and read, build or review client code with the official SDKs (Python, Node.js, Go, Java, C#), and design or review a data model, whether from requirements or against a schema that already exists. Covers namespaces, sets, bins, primary key design, TTL and NSUP, collection data types, expressions, secondary indexes, batch and scan workflows, client policies, connection pooling, record sizing, and schema deliverables. Use when the user sets up Aerospike, writes or debugs Aerospike client code, chooses keys or models data for it, reviews an Aerospike schema before building, or evaluates it as a persistent replacement for Redis or Memcached in real-time, low-latency, feature-store, or user-profile workloads. Core database only — not Aerospike Graph, and not cluster operations, sizing, XDR, or backup and restore, which belong to Aerospike Operations documentation.
 license: Apache-2.0
 metadata:
   last_verified: "2026-04-21"

--- a/compiled-skills/manifest.json
+++ b/compiled-skills/manifest.json
@@ -7,6 +7,6 @@
     "skills/aerospike-data-modeling"
   ],
   "files": {
-    "compiled-skills/aerospike/SKILL.md": 44831
+    "compiled-skills/aerospike/SKILL.md": 44804
   }
 }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -88,10 +88,14 @@ The script resolves the repository through `POST /api/skills/validate` first, th
 }
 ```
 
-Two behaviors worth knowing:
+Four behaviors worth knowing:
 
+- **Use the `www` host.** The bare `openagentskill.com` answers every API request with a 307 to `www.openagentskill.com`. A `curl` without `-L` reads that as a failure, which is how the first live publish attempt died — reporting "the repository is not publicly readable yet" about a public repository. The script now targets the canonical host *and* follows redirects.
+- **Frontmatter is parsed by line, not by a YAML parser.** With `description: >-`, `/validate` returned the literal string `">-"` as our description. The description is what drives trigger matching and what a human reads, so the published frontmatter keeps it on **one line** as a plain scalar — the only form a real YAML parser and a line-based parser agree on. That rules out `": "` anywhere in the text. A unit test enforces it; do not reformat it into a block scalar.
 - **Re-submission is expected and safe.** A duplicate response is treated as success, which is what makes a release-triggered refresh idempotent.
 - **Listed and recommended are different states.** Only Reviewed, Verified, or Agent Proven skills enter default agent recommendations. Appearing in the directory does not mean agents will suggest us.
+
+`/validate` ignores any `ref` and always reads the default branch, so a fix cannot be rehearsed from a branch — it has to land on `main` before the registry will see it.
 
 Each submission returns `{id, token, statusUrl}`. **The token is the only way to poll that submission later.** Tokens are private, so the workflow keeps them out of logs and the job summary, uploading them as the `registry-receipts` artifact (90-day retention). Transcribe them into the table below before the artifact expires.
 

--- a/scripts/publish-openagentskill.sh
+++ b/scripts/publish-openagentskill.sh
@@ -9,7 +9,10 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-API="${OAS_API:-https://openagentskill.com/api}"
+# The www host is canonical: the bare domain answers every request with a 307 to it.
+# Both curl calls below pass -L so a future redirect is followed rather than read as
+# a failure, but keep this pointed at the canonical host so the redirect never happens.
+API="${OAS_API:-https://www.openagentskill.com/api}"
 REPO_URL=""
 AGENT_ID="aerospike-agent-skills-ci"
 RECEIPTS=""
@@ -58,14 +61,22 @@ SKILL_PATH="compiled-skills/${SKILL_NAME}/SKILL.md"
 if [[ "${DRY_RUN}" -eq 0 ]]; then
   echo "Resolving skill paths via ${API}/skills/validate"
   validate_body="$(jq -cn --arg repository "${REPO_URL}" '{repository: $repository}')"
-  validate_out="$(curl -sS -X POST "${API}/skills/validate" \
+  validate_out="$(curl -sSL -X POST "${API}/skills/validate" \
     -H 'Content-Type: application/json' \
     -d "${validate_body}" \
     -w '\n%{http_code}')"
   validate_code="$(tail -n1 <<<"${validate_out}")"
   if [[ "${validate_code}" != 2* ]]; then
     echo "Registry could not read ${REPO_URL} (HTTP ${validate_code})." >&2
-    echo "This usually means the repository is not publicly readable yet." >&2
+    # A 3xx here is our own misconfiguration, not a visibility problem. Saying so
+    # matters: the old message blamed repository visibility for every failure and
+    # sent one investigation looking at the wrong thing entirely.
+    if [[ "${validate_code}" == 3* ]]; then
+      echo "The endpoint redirected and the redirect was not followed. Check that" >&2
+      echo "the API base points at the canonical host: ${API}" >&2
+    else
+      echo "This usually means the repository is not publicly readable yet." >&2
+    fi
     sed '$d' <<<"${validate_out}" >&2
     exit 1
   fi
@@ -95,7 +106,7 @@ for name in "${SKILL_NAME}"; do
   fi
 
   echo "Submitting ${name}"
-  response="$(curl -sS -X POST "${API}/skills/submit" \
+  response="$(curl -sSL -X POST "${API}/skills/submit" \
     -H 'Content-Type: application/json' \
     -d "${payload}" \
     -w '\n%{http_code}')"

--- a/scripts/skills_compile/published_skill.yaml
+++ b/scripts/skills_compile/published_skill.yaml
@@ -1,18 +1,5 @@
 name: aerospike
-description: >-
-  Work with the Aerospike core database end to end: run a local instance with
-  Docker and verify a first write and read, build or review client code with the
-  official SDKs (Python, Node.js, Go, Java, C#), and design or review a
-  data model, whether from requirements or against a schema that already
-  exists. Covers namespaces, sets, bins, primary key design, TTL and NSUP,
-  collection data types, expressions, secondary indexes, batch and scan
-  workflows, client policies, connection pooling, record sizing, and schema
-  deliverables. Use when the user sets up Aerospike, writes or debugs Aerospike
-  client code, chooses keys or models data for it, reviews an Aerospike schema
-  before building, or evaluates it as a persistent replacement for Redis or
-  Memcached in real-time, low-latency, feature-store, or user-profile workloads.
-  Core database only: not Aerospike Graph, and not cluster operations, sizing,
-  XDR, or backup and restore, which belong to Aerospike Operations documentation.
+description: Work with the Aerospike core database end to end — run a local instance with Docker and verify a first write and read, build or review client code with the official SDKs (Python, Node.js, Go, Java, C#), and design or review a data model, whether from requirements or against a schema that already exists. Covers namespaces, sets, bins, primary key design, TTL and NSUP, collection data types, expressions, secondary indexes, batch and scan workflows, client policies, connection pooling, record sizing, and schema deliverables. Use when the user sets up Aerospike, writes or debugs Aerospike client code, chooses keys or models data for it, reviews an Aerospike schema before building, or evaluates it as a persistent replacement for Redis or Memcached in real-time, low-latency, feature-store, or user-profile workloads. Core database only — not Aerospike Graph, and not cluster operations, sizing, XDR, or backup and restore, which belong to Aerospike Operations documentation.
 license: Apache-2.0
 metadata:
   last_verified: "2026-04-21"

--- a/tests/unit/test_compile_published_skill.py
+++ b/tests/unit/test_compile_published_skill.py
@@ -70,6 +70,37 @@ def test_description_covers_all_three_source_domains(published):
         assert excluded in lowered, f"description should rule out {excluded!r}"
 
 
+def test_description_is_one_line_so_naive_registry_parsers_read_it(published):
+    """openagentskill parses frontmatter by line, not with a YAML parser.
+
+    With a folded block scalar (``description: >-``) its /validate endpoint
+    returned the literal string ">-" as our description -- the text that drives
+    trigger matching and that a human reads before installing. Submissions cannot
+    be deleted, so a reformat here would permanently degrade the listing.
+
+    A single-line plain scalar is the one form both a real YAML parser and a
+    "rest of the line" parser agree on. That rules out ": " anywhere in the text,
+    which would otherwise make the plain scalar invalid YAML.
+    """
+    _, text = published
+    frontmatter = text[4 : text.index("\n---", 4)]
+
+    line = next(
+        ln for ln in frontmatter.splitlines() if ln.startswith("description:")
+    )
+    naive = line.split(":", 1)[1].strip()
+
+    assert not naive.startswith((">", "|")), (
+        "description must not use a YAML block scalar; registries that parse by "
+        "line would read the indicator instead of the text"
+    )
+
+    from scripts.skills_compile.skillsrc import split_frontmatter
+
+    meta, _ = split_frontmatter(text)
+    assert meta["description"] == naive
+
+
 def test_header_carries_the_repository_url_for_cited_rule_files(compiler, published):
     _, text = published
     assert compiler.REPO_URL in text


### PR DESCRIPTION
# Description

The first live publish attempt ([run 33008775580](https://github.com/aerospike/agent-skills/actions/runs/33008775580)) failed at the `/validate` call and blamed repository visibility for a repository that is public. Investigating that turned up a second, worse defect that would not have failed anything — it would have produced a permanently bad listing.

Nothing was submitted to either registry in that run: the openagentskill step failed before the submit loop, and the upskill step was skipped.

**1. Wrong host.** `openagentskill.com` answers every API request with a 307 to `www.openagentskill.com`. `curl` was invoked with `-sS` and no `-L`, and the script treats any non-2xx as failure:

```
POST https://openagentskill.com/api/skills/validate      → 307, Location: www...
POST https://www.openagentskill.com/api/skills/validate  → 200, {"valid":true,...}
```

`docs/PUBLISHING.md` has had the `www` form in its listing URL all along; only the script omitted it.

**2. The description would have listed as `>-`.** openagentskill parses frontmatter by line rather than with a YAML parser. Against `main` today, `/validate` returns:

```json
"skills":[{"name":"aerospike","description":">-"},
          {"name":"aerospike-data-modeling","description":">-"},
          {"name":"aerospike-development","description":">-"},
          {"name":"aerospike-getting-started","description":">-"}]
```

It reads whatever follows `description:` on that line, which for a folded block scalar is the indicator. The description is what drives trigger matching and what a human reads before installing, and no registry documents a way to delete a submission — so publishing as-is would have made `>-` our permanent first impression.

## Changes

- `scripts/publish-openagentskill.sh`: default `OAS_API` to the `www` host, add `-L` to both calls so a future redirect is followed rather than read as a failure, and distinguish a 3xx from a visibility problem in the error message.
- `scripts/skills_compile/published_skill.yaml`: the description becomes a single-line plain scalar — the only form a real YAML parser and a line-based parser agree on. A plain scalar cannot contain `": "`, so two colons became em dashes. No other wording changed.
- `compiled-skills/aerospike/SKILL.md` and `manifest.json`: recompiled.
- `tests/unit/test_compile_published_skill.py`: new test asserting the YAML parse and the naive line parse produce the same string, and that the value is not a block scalar. Nothing else would catch someone reformatting it back.
- `docs/PUBLISHING.md`: both traps recorded under the openagentskill section, plus the note that `/validate` ignores any `ref`.

Only the published artifact changes. The three sources under `skills/` keep their block scalars, which are more readable and are consumed by agents that parse YAML properly.

## How to Test

- `python3 -m pytest tests/unit -q` — 94 passed, including the new guard.
- `./scripts/validate-spec.sh` — all 4 skills conform to the Agent Skills specification.
- `./scripts/validate-skill.sh --ci` — exit 2 (warnings-only, which CI treats as pass). Compared against a worktree at the pre-change commit: the same two warnings appear there (13 comma-separated segments, 9168-token body), so this adds none.
- `python3 scripts/compile-agents.py --shape stripped --check` — up to date.
- Both parses agree on the new value:

```
proper == naive : True
contains ": "   : False
```

## Limits of this verification

The description fix **cannot be confirmed against the registry from a branch**: `/validate` ignores a `ref` and always reads the default branch. I probed it with `{"repository": ..., "ref": "..."}` and it still returned `ref: main` for every skill. So the first real confirmation is a `/validate` call after this merges — worth doing before the publish run, since it is cheap and read-only:

```bash
curl -sS -X POST https://www.openagentskill.com/api/skills/validate \
  -H 'Content-Type: application/json' \
  -d '{"repository":"https://github.com/aerospike/agent-skills"}' | jq '.skills[] | select(.name=="aerospike")'
```

Expect the real description text rather than `>-`.

## Notes for the reviewer

- `REGISTRY_PUBLISH_ENABLED` is now `true`, so the next release run will submit for real. There is no approval gate left to catch a mistake, which is why the `/validate` check above is worth running first.
- `last_verified` is still `2026-04-21` and unaddressed here.
- Pre-existing and left alone: `shellcheck` flags SC2066 on the single-element `for name in "${SKILL_NAME}"` loop, identically at `HEAD`. No CI job runs shellcheck.

## Self-Review Checklist

- [x] Code follows project conventions
- [x] Tests added or updated as needed
- [x] No unrelated changes included