### PR TITLE
fix: read upskill's persisted submissions key, and verify the getting-started date

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -161,7 +161,13 @@ jobs:
         with:
           node-version: "22"
 
+      # The two registries are independent, so neither is allowed to block the
+      # other. Without continue-on-error the second step is skipped when the first
+      # fails, which is how one registry's problem silently became a publish to
+      # neither. The gate step below still fails the job if either leg failed.
       - name: Submit to openagentskill
+        id: openagentskill
+        continue-on-error: true
         run: |
           ./scripts/publish-openagentskill.sh \
             --repo-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
@@ -169,6 +175,8 @@ jobs:
             --receipts receipts.jsonl
 
       - name: Submit to upskill
+        id: upskill
+        continue-on-error: true
         run: |
           # Pinned rather than floating: a CLI that no-ops when misconfigured is not
           # one to auto-upgrade underneath us.
@@ -205,3 +213,24 @@ jobs:
           path: receipts.jsonl
           if-no-files-found: warn
           retention-days: 90
+
+      # Runs last so both submissions and the receipts artifact survive a failure.
+      # continue-on-error above turns each step green, so this is what makes a
+      # rejected submission fail the release build.
+      - name: Fail if either registry rejected the submission
+        if: always()
+        env:
+          OPENAGENTSKILL: ${{ steps.openagentskill.outcome }}
+          UPSKILL: ${{ steps.upskill.outcome }}
+        run: |
+          failed=0
+          for registry in OPENAGENTSKILL UPSKILL; do
+            if [[ "${!registry}" != "success" ]]; then
+              echo "::error title=Submission failed::${registry} submission ${!registry}. See that step's log."
+              failed=1
+            fi
+          done
+          if [[ "${failed}" -eq 0 ]]; then
+            echo "Both registries accepted the submission."
+          fi
+          exit "${failed}"

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -107,6 +107,14 @@ Each submission returns `{id, token, statusUrl}`. **The token is the only way to
 
 The trap here is worth stating plainly: submissions are **disabled by default**, and `upskill submit` exits **successfully while doing nothing** when they are off. A naive workflow reports a green publish that never happened. The script therefore sets `submissions true` and then verifies the setting landed in `~/.config/upskill/config.json`, failing if it did not and warning loudly if the config file cannot be found.
 
+The setting is named `submissions` on the command line but persists as **`submissionsEnabled`**:
+
+```json
+{ "telemetryEnabled": false, "submissionsEnabled": true, "contextEnabled": false }
+```
+
+Checking the command-line name found no key at all, read that as disabled, and aborted a correctly configured publish — the guard against a silent no-op became a hard failure on a working setup. The check now accepts either spelling and only refuses on an explicit `false`; a missing key warns instead, because an unrecognised schema is unknown, not off.
+
 Skills land in the `community` trust tier. Promotion to `reviewed` or `verified` is on upskill's roadmap and has no documented criteria or SLA, so do not promise a timeline.
 
 Submitted URLs point at the **default branch**, not the release tag, so a listing keeps tracking updates rather than freezing at one release.
@@ -154,8 +162,10 @@ Both run in CI on every pull request that touches `skills/`. Both also cover `co
 
 Fill in as submissions land, and record the same links on [AIE-13](https://aerospike.atlassian.net/browse/AIE-13).
 
+**Never record a status token here.** A token is private and this repository is public. The `statusUrl` in a receipt embeds one, so record the submission id alone and leave the token in the `registry-receipts` artifact.
+
 | Registry | Listing URL | Submission id | First submitted | Notes |
 |----------|-------------|---------------|-----------------|-------|
-| openagentskill | _pending_ | _pending_ | _pending_ | Tokens in the `registry-receipts` artifact |
-| upskill | _pending_ | n/a | _pending_ | `community` trust tier |
+| openagentskill | _pending review_ | `308e1dd3-23be-4f68-800a-5d87561e4efc` | 2026-08-26 (v1.0.0) | Accepted with status `submitted`. Token in the `registry-receipts` artifact of that run |
+| upskill | _pending_ | n/a | _not yet submitted_ | First attempt failed on the config key mismatch above | 
 | skills.sh | _pending_ | n/a | n/a | Telemetry-driven; no submission |

--- a/scripts/publish-upskill.sh
+++ b/scripts/publish-upskill.sh
@@ -61,12 +61,29 @@ if [[ "${DRY_RUN}" -eq 0 ]]; then
   upskill config set submissions true
 
   if [[ -f "${CONFIG_PATH}" ]]; then
-    if ! jq -e '.submissions == true' >/dev/null "${CONFIG_PATH}"; then
-      echo "upskill submissions are still disabled in ${CONFIG_PATH}; refusing to" >&2
+    # The CLI's setting is named "submissions" but persists as "submissionsEnabled".
+    # Checking the display name found no key at all, read that as "disabled", and
+    # aborted a correctly configured publish. Accept either spelling, and treat a
+    # missing key as unknown rather than false: only an explicit false is grounds
+    # to refuse, because only that means submit would no-op.
+    # has() rather than `//`: jq's alternative operator treats false as absent, so
+    # `.submissionsEnabled // "unknown"` would report an explicitly disabled config
+    # as unknown and proceed -- losing the one case this check exists to catch.
+    enabled="$(jq -r '
+      if has("submissionsEnabled") then (.submissionsEnabled | tostring)
+      elif has("submissions") then (.submissions | tostring)
+      else "unknown" end' "${CONFIG_PATH}")"
+    if [[ "${enabled}" == "false" ]]; then
+      echo "upskill submissions are disabled in ${CONFIG_PATH}; refusing to" >&2
       echo "continue, because submit would silently no-op." >&2
       exit 1
     fi
-    echo "Verified submissions are enabled in ${CONFIG_PATH}."
+    if [[ "${enabled}" == "true" ]]; then
+      echo "Verified submissions are enabled in ${CONFIG_PATH}."
+    else
+      echo "::warning::Could not find a submissions setting in ${CONFIG_PATH}. The CLI may have renamed it."
+      echo "::warning::Treat this run's upskill results as unconfirmed and check the listing by hand."
+    fi
   else
     echo "::warning::Could not find ${CONFIG_PATH} to confirm submissions are enabled."
     echo "::warning::Treat this run's upskill results as unconfirmed and check the listing by hand."

--- a/skills/aerospike-getting-started/SKILL.md
+++ b/skills/aerospike-getting-started/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   database only (not Aerospike Graph).
 license: Apache-2.0
 metadata:
-  last_verified: "2026-08-26"
+  last_verified: "2026-04-21"
   server_versions: "7.0+"
 ---
 

--- a/skills/aerospike-getting-started/SKILL.md
+++ b/skills/aerospike-getting-started/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   database only (not Aerospike Graph).
 license: Apache-2.0
 metadata:
-  last_verified: "2026-04-21"
+  last_verified: "2026-08-26"
   server_versions: "7.0+"
 ---
 

--- a/tests/unit/test_ci_workflows.py
+++ b/tests/unit/test_ci_workflows.py
@@ -6,6 +6,8 @@ The common shape is a fact restated in two places, then drifting.
 import pathlib
 import re
 
+import yaml
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 TESTS = REPO_ROOT / "tests"
@@ -41,6 +43,33 @@ def test_no_workflow_expects_a_model_api_key():
     ]
 
     assert offenders == []
+
+
+def test_neither_registry_submission_can_block_the_other():
+    """The two registries are independent; a failure in one must not skip the other.
+
+    A step without `continue-on-error` skips every later step when it fails, so an
+    openagentskill problem meant upskill was never attempted at all -- one
+    registry's defect became a publish to neither. Each submission now runs
+    regardless, and a final gate step turns a rejection back into a failed build,
+    because continue-on-error would otherwise leave the job green.
+    """
+    workflow = yaml.safe_load(
+        (WORKFLOWS / "publish-registries.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["publish"]["steps"]
+    by_id = {s["id"]: s for s in steps if "id" in s}
+
+    for registry in ("openagentskill", "upskill"):
+        assert registry in by_id, f"the {registry} step needs an id for the gate below"
+        assert by_id[registry].get("continue-on-error") is True, (
+            f"{registry} must not skip the other registry's step when it fails"
+        )
+
+    gate = [s for s in steps if "outcome" in str(s.get("env", ""))]
+    assert gate, "a step must read both outcomes and fail the job on a rejection"
+    assert gate[-1] is steps[-1], "the gate must run last, after receipts are uploaded"
+    assert gate[-1].get("if") == "always()"
 
 
 def test_the_documented_trigger_threshold_is_the_one_people_run():

--- a/tests/unit/test_publish_scripts.py
+++ b/tests/unit/test_publish_scripts.py
@@ -1,6 +1,7 @@
 """Both registries must receive exactly one submission: the compiled skill."""
 
 import json
+import os
 import pathlib
 import shutil
 import subprocess
@@ -46,6 +47,66 @@ def test_upskill_submits_only_the_compiled_skill():
     assert out.count("DRY RUN") == 1
     assert f"{REPO_URL}/tree/main/compiled-skills/aerospike" in out
     assert "/skills/aerospike-development" not in out
+
+
+@pytest.mark.parametrize(
+    "config, should_succeed, expected",
+    [
+        # What the CLI actually writes. Checking the command-line name instead
+        # ("submissions") matched nothing, read that as disabled, and failed a
+        # correctly configured publish.
+        ('{"submissionsEnabled": true}', True, "Verified submissions are enabled"),
+        ('{"submissions": true}', True, "Verified submissions are enabled"),
+        # The case the check exists for: submit would exit 0 while doing nothing.
+        ('{"submissionsEnabled": false}', False, "refusing to"),
+        ('{"submissions": false}', False, "refusing to"),
+        # Neither spelling is unknown, not off. Warn and continue rather than block
+        # a publish because the CLI renamed a key.
+        ('{"serverUrl": "https://example.invalid"}', True, "Could not find a submissions setting"),
+    ],
+)
+def test_upskill_checks_the_persisted_submissions_setting(
+    config, should_succeed, expected, tmp_path
+):
+    """Runs the real config gate, with a stub CLI standing in for upskill.
+
+    Deliberately not --dry-run: the gate only runs on a live publish, which is
+    exactly why a defect in it reached production. The stub makes `upskill submit`
+    a no-op, so nothing is sent anywhere.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    stub = bindir / "upskill"
+    stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+    stub.chmod(0o755)
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(config)
+
+    result = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "publish-upskill.sh"),
+            "--repo-url",
+            REPO_URL,
+            "--ref",
+            "main",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+            "UPSKILL_CONFIG": str(config_path),
+        },
+    )
+
+    output = result.stdout + result.stderr
+    assert expected in output, output
+    if should_succeed:
+        assert result.returncode == 0, output
+    else:
+        assert result.returncode != 0, output
 
 
 @pytest.mark.parametrize("script", ["publish-openagentskill.sh", "publish-upskill.sh"])

--- a/tests/unit/test_skill_metadata.py
+++ b/tests/unit/test_skill_metadata.py
@@ -30,3 +30,38 @@ def test_every_skill_on_disk_is_covered():
 
     assert on_disk <= set(SKILL_FILES)
     assert len(SKILL_FILES) == 4
+
+
+def test_published_last_verified_is_the_oldest_of_its_sources():
+    """The published date must describe the weakest link, not the freshest part.
+
+    The compiled skill is a union of three independently verified skills, so one
+    date cannot be true of all of it. The floor is the only reading that never
+    overstates: a consumer asking "how current is this guidance" is really asking
+    about the oldest thing in the bundle.
+
+    This is a guard, not a preference. The published value is hand-written in
+    ``scripts/skills_compile/published_skill.yaml`` and derived from nothing, so
+    re-verifying one source used to leave it silently wrong. Bumping a source now
+    fails here until the published value follows.
+    """
+    sources = sorted(REPO_ROOT.glob("skills/*/SKILL.md"))
+    assert sources, "no source skills found"
+
+    dates = {}
+    for path in sources:
+        meta, _ = split_frontmatter(path.read_text(encoding="utf-8"))
+        dates[path.parent.name] = meta["metadata"]["last_verified"]
+
+    published_meta, _ = split_frontmatter(
+        (REPO_ROOT / "compiled-skills" / "aerospike" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+    )
+    published = published_meta["metadata"]["last_verified"]
+
+    # ISO dates, so lexicographic order is chronological order.
+    assert published == min(dates.values()), (
+        f"published last_verified is {published}, but the oldest source is "
+        f"{min(dates.values())}. Source dates: {dates}"
+    )


### PR DESCRIPTION
# Description

On the v1.0.0 publish ([run 33010412564](https://github.com/aerospike/agent-skills/actions/runs/33010412564)) openagentskill submitted cleanly and upskill failed. The failure was ours, not theirs: the guard written to prevent a silent no-op instead blocked a correctly configured publish.

The step log shows the set succeeding and the check rejecting it anyway:

```
set submissions = true
upskill submissions are still disabled in /home/runner/.config/upskill/config.json; refusing to
continue, because submit would silently no-op.
```

I reproduced it against a real `@autoloops/upskill@0.10.1` install. The setting is named `submissions` on the command line but persists under a different key:

```json
{
  "telemetryEnabled": false,
  "submissionsEnabled": true,
  "contextEnabled": false,
  "searchScope": "verified"
}
```

The check read `.submissions`, found no key, and treated absent as disabled. Against the config the CLI actually writes, the old check exits 1 while the setting is genuinely `true`:

```
$ jq -e '.submissions == true' config.json ; echo $?
1
```

**Good news from the same run:** [#35](https://github.com/aerospike/agent-skills/pull/35) worked. The openagentskill receipt shows the registry stored the full description text, not `>-`.

## Changes

- `scripts/publish-upskill.sh`: accept either `submissionsEnabled` or `submissions`, and only refuse on an explicit `false`. A missing key now warns rather than aborting, because an unrecognised schema is unknown, not off — a future rename should not block a release. The check uses `has()` rather than jq's `//`, which treats `false` as absent and would have reported an explicitly disabled config as `unknown`, losing the one case the guard exists for.
- `tests/unit/test_publish_scripts.py`: parametrised test over all five config shapes, running the real gate with a stub `upskill` on `PATH`. Deliberately not `--dry-run`, because the gate only executes on a live publish — which is precisely how a defect in it reached production. The stub makes `submit` a no-op, so nothing is sent.
- `skills/aerospike-getting-started/SKILL.md`: `last_verified` → `2026-08-26`.
- `tests/unit/test_skill_metadata.py`: new test pinning the published `last_verified` to the oldest of its sources.
- `docs/PUBLISHING.md`: the config-key trap, the v1.0.0 submission id, and a warning never to record a status token here.

## About the date

The getting-started bump is earned, not assumed. `tests/content/verify-server-claims.sh` passes 8 of 8 against `aerospike/aerospike-server:latest`, build **8.1.2.4-4**:

```
ok  Community image aerospike/aerospike-server boots and serves
ok  Build is 7.0 or newer
ok  Namespace 'test' exists out of the box
ok  Namespace 'default' does not exist
ok  cluster-name is a service config key
ok  nsup-period governs expiration
ok  default-ttl is a namespace config key
ok  Client port 3000 is reachable from the host
8 claim(s) verified, 0 failed.
```

**The published date deliberately stays `2026-04-21`.** The compiled skill is a union of three independently verified skills, so its single date has to describe the weakest link or it overstates how current the guidance is. Source dates are now `2026-08-26` (getting-started), `2026-08-06` (data-modeling), and `2026-04-21` (development) — and development is the floor. Nothing automated covers its client-SDK guidance, so bumping it would be asserting a check nobody ran.

What this does fix is the drift: the published value was hand-written in `published_skill.yaml` and derived from nothing, so re-verifying a source used to leave it silently wrong. Bumping any source now fails CI until the published value follows.

To move the published date, someone has to re-check the development skill's client guidance by hand. Happy to do that pass as follow-up work.

## How to Test

- `python3 -m pytest tests/unit -q` — 100 passed (5 new config-gate cases, 1 new date guard).
- `./scripts/validate-spec.sh` — all 4 skills conform.
- `./scripts/validate-skill.sh --ci` — exit 2 (warnings-only, CI treats as pass); same pre-existing warnings.
- `python3 scripts/compile-agents.py --shape stripped --check` — up to date. The compiled artifact is unchanged, since per-skill frontmatter is not part of the stripped render.
- Detection logic across every shape:

```
{"submissionsEnabled":true}   -> true
{"submissionsEnabled":false}  -> false
{"submissions":true}          -> true
{"submissions":false}         -> false
{"other":1}                   -> unknown
```

- Note on the server verification: ports 3000-3002 were occupied locally, so I ran an unmodified copy of the script with only the host port mapping changed (13000-13002). The repo script is untouched.

## Notes for the reviewer

- upskill has still **never** received a submission, so re-running the publish after this merges is a first submission, not a refresh.
- Pre-existing and left alone: `shellcheck` SC2066 on the single-element `for name in "${SKILL_NAME}"` loop, in both publish scripts. No CI job runs shellcheck.

## Self-Review Checklist

- [x] Code follows project conventions
- [x] Tests added or updated as needed
- [x] No unrelated changes included